### PR TITLE
Add Seshat data download and parsing modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ dependencies = [
     "numpy>=1.24",
     "scipy>=1.10",
     "matplotlib>=3.7",
+    "requests>=2.28",
+    "openpyxl>=3.1",
 ]
 
 [project.optional-dependencies]

--- a/src/cliodynamics/data/__init__.py
+++ b/src/cliodynamics/data/__init__.py
@@ -1,1 +1,57 @@
-"""Data access module for Seshat and other historical datasets."""
+"""
+Data access module for Seshat and other historical datasets.
+
+This module provides tools for downloading and parsing the Seshat
+Global History Databank (Equinox-2020 release).
+
+Key Functions:
+    download_and_extract: Download Seshat dataset from Zenodo
+    load_equinox: Load and parse the Seshat Equinox-2020 dataset
+    parse_value: Parse individual Seshat data values
+
+Key Classes:
+    SeshatDataset: Container for parsed Seshat data
+    Polity: A political entity with its variables
+    ParsedValue: A parsed data value with uncertainty info
+    DataQuality: Enum for data quality indicators
+
+Usage:
+    >>> from cliodynamics.data import download_and_extract, load_equinox
+    >>> # First, download the dataset
+    >>> download_and_extract()
+    >>> # Then load and parse it
+    >>> dataset = load_equinox()
+    >>> print(f"Loaded {len(dataset.polities)} polities")
+"""
+
+from cliodynamics.data.download import download_and_extract, get_zenodo_download_url
+from cliodynamics.data.parser import (
+    DataQuality,
+    ParsedValue,
+    Polity,
+    SeshatDataset,
+    get_variable_summary,
+    load_equinox,
+    load_seshat_csv,
+    load_seshat_excel,
+    parse_seshat_dataframe,
+    parse_value,
+)
+
+__all__ = [
+    # Download functions
+    "download_and_extract",
+    "get_zenodo_download_url",
+    # Parser classes
+    "DataQuality",
+    "ParsedValue",
+    "Polity",
+    "SeshatDataset",
+    # Parser functions
+    "get_variable_summary",
+    "load_equinox",
+    "load_seshat_csv",
+    "load_seshat_excel",
+    "parse_seshat_dataframe",
+    "parse_value",
+]

--- a/src/cliodynamics/data/download.py
+++ b/src/cliodynamics/data/download.py
@@ -1,0 +1,216 @@
+"""
+Download Seshat Equinox-2020 dataset from Zenodo.
+
+The Seshat Global History Databank (Equinox-2020 release) contains ~100 variables
+for 373 societies spanning 9600 BCE to 1900 CE.
+
+Dataset DOI: https://doi.org/10.5281/zenodo.6642229
+License: CC-BY-NC-SA
+
+Usage:
+    python -m cliodynamics.data.download
+
+This will download and extract the dataset to the data/ directory.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import zipfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import requests
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# Zenodo record ID for Seshat Equinox-2020
+ZENODO_RECORD_ID = "6642230"
+
+# API endpoint for Zenodo
+ZENODO_API_URL = f"https://zenodo.org/api/records/{ZENODO_RECORD_ID}"
+
+# Expected filename in the archive
+EXPECTED_EXCEL_FILE = "Equinox_on_GitHub_June9_2022.xlsx"
+
+# Default download directory (relative to project root)
+DEFAULT_DATA_DIR = Path("data")
+
+
+def get_zenodo_download_url() -> str:
+    """
+    Fetch the download URL for the Seshat dataset from Zenodo API.
+
+    Returns:
+        The direct download URL for the zip archive.
+
+    Raises:
+        requests.HTTPError: If the API request fails.
+        ValueError: If no downloadable files are found in the record.
+    """
+    logger.info("Fetching Zenodo record metadata...")
+    response = requests.get(ZENODO_API_URL, timeout=30)
+    response.raise_for_status()
+
+    record = response.json()
+    files = record.get("files", [])
+
+    if not files:
+        raise ValueError(f"No files found in Zenodo record {ZENODO_RECORD_ID}")
+
+    # Look for the zip file
+    for file_info in files:
+        filename = file_info.get("key", "")
+        if filename.endswith(".zip"):
+            download_url = file_info.get("links", {}).get("self")
+            if download_url:
+                logger.info(f"Found download URL for: {filename}")
+                return download_url
+
+    # Fallback to first file if no zip found
+    first_file = files[0]
+    download_url = first_file.get("links", {}).get("self")
+    if download_url:
+        return download_url
+
+    raise ValueError("Could not find download URL in Zenodo record")
+
+
+def download_and_extract(
+    data_dir: Path | str | None = None,
+    force: bool = False,
+) -> Path:
+    """
+    Download and extract the Seshat Equinox-2020 dataset.
+
+    Args:
+        data_dir: Directory to store the downloaded data. Defaults to ./data/
+        force: If True, re-download even if files already exist.
+
+    Returns:
+        Path to the extracted data directory.
+
+    Raises:
+        requests.HTTPError: If download fails.
+        zipfile.BadZipFile: If the downloaded archive is corrupted.
+
+    Example:
+        >>> from cliodynamics.data.download import download_and_extract
+        >>> data_path = download_and_extract()
+        >>> print(data_path)
+        data/seshat
+    """
+    if data_dir is None:
+        data_dir = DEFAULT_DATA_DIR
+    else:
+        data_dir = Path(data_dir)
+
+    # Create output directory
+    seshat_dir = data_dir / "seshat"
+
+    # Check if already downloaded
+    expected_file = seshat_dir / EXPECTED_EXCEL_FILE
+    if expected_file.exists() and not force:
+        logger.info(f"Dataset already exists at {expected_file}")
+        return seshat_dir
+
+    # Get download URL
+    download_url = get_zenodo_download_url()
+
+    # Download the file
+    logger.info("Downloading Seshat dataset from Zenodo...")
+    logger.info(f"URL: {download_url}")
+
+    response = requests.get(download_url, stream=True, timeout=300)
+    response.raise_for_status()
+
+    # Get total size for progress reporting
+    total_size = int(response.headers.get("content-length", 0))
+    logger.info(f"Total size: {total_size / 1024 / 1024:.1f} MB")
+
+    # Read content into memory
+    content = io.BytesIO()
+    downloaded = 0
+    for chunk in response.iter_content(chunk_size=8192):
+        content.write(chunk)
+        downloaded += len(chunk)
+        if total_size > 0:
+            pct = downloaded / total_size * 100
+            logger.debug(f"Downloaded {pct:.1f}%")
+
+    content.seek(0)
+
+    # Create directories
+    seshat_dir.mkdir(parents=True, exist_ok=True)
+
+    # Extract the archive
+    logger.info(f"Extracting to {seshat_dir}...")
+    with zipfile.ZipFile(content, "r") as zf:
+        # List contents
+        names = zf.namelist()
+        logger.info(f"Archive contains {len(names)} files")
+
+        # Extract all files
+        for name in names:
+            # Skip directories and hidden files
+            if name.endswith("/") or name.startswith("."):
+                continue
+
+            # Get just the filename (strip any directory prefix)
+            filename = Path(name).name
+
+            # Skip non-data files
+            if not (
+                filename.endswith(".xlsx")
+                or filename.endswith(".csv")
+                or filename.endswith(".txt")
+            ):
+                continue
+
+            # Extract to seshat_dir with flat structure
+            logger.info(f"Extracting: {filename}")
+            data = zf.read(name)
+            (seshat_dir / filename).write_bytes(data)
+
+    logger.info(f"Download complete. Data stored in: {seshat_dir}")
+    return seshat_dir
+
+
+def main() -> None:
+    """Main entry point for command-line usage."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    # Find project root (go up from this file)
+    # This module is at: src/cliodynamics/data/download.py
+    # Project root has: pyproject.toml, data/
+    module_path = Path(__file__).resolve()
+    src_path = module_path.parent.parent.parent  # up from data/ to src/
+    project_root = src_path.parent  # up from src/ to project root
+
+    data_dir = project_root / "data"
+    logger.info(f"Data directory: {data_dir}")
+
+    try:
+        output_path = download_and_extract(data_dir)
+        print(f"\nSeshat Equinox-2020 dataset downloaded to: {output_path}")
+        print("\nAvailable files:")
+        for f in sorted(output_path.iterdir()):
+            size_mb = f.stat().st_size / 1024 / 1024
+            print(f"  {f.name} ({size_mb:.2f} MB)")
+    except requests.HTTPError as e:
+        logger.error(f"Download failed: {e}")
+        raise SystemExit(1) from e
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        raise SystemExit(1) from e
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cliodynamics/data/parser.py
+++ b/src/cliodynamics/data/parser.py
@@ -1,0 +1,511 @@
+"""
+Parse Seshat Equinox-2020 dataset into Python data structures.
+
+Schema Overview
+---------------
+The Seshat Global History Databank tracks ~100 variables for 373 polities
+(societies) from 9600 BCE to 1900 CE.
+
+Key Columns:
+- NGA (Natural Geographic Area): Geographic region identifier
+- Polity: Political entity identifier (e.g., "RomPrin" for Roman Principate)
+- Original_name: Full polity name
+- Start/End: Temporal bounds in CE years (negative = BCE)
+- Variable columns: Various social complexity indicators
+
+Temporal Encoding:
+- Years are in CE format (negative values = BCE)
+- E.g., -500 means 500 BCE, 1200 means 1200 CE
+- Date ranges may be expressed as intervals: "300-600" meaning uncertain
+
+Value Conventions:
+- "present" / "absent": Binary presence/absence
+- "inferred present" / "inferred absent": Expert inference
+- "unknown" / "uncoded": Missing data
+- Numeric values: Population sizes, territory area, etc.
+- "[X-Y]": Range indicating uncertainty (e.g., "[100-500]")
+- "suspected unknown": Searched but not found
+- Empty cells: Not coded
+
+Uncertainty Markers:
+- "inferred": Value inferred from indirect evidence
+- "disputed": Experts disagree on value
+- "uncertain": Low confidence in value
+- Range notation "[X-Y]" or "X-Y": Numeric uncertainty
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+class DataQuality(Enum):
+    """Quality indicators for Seshat data values."""
+
+    PRESENT = "present"
+    ABSENT = "absent"
+    INFERRED_PRESENT = "inferred_present"
+    INFERRED_ABSENT = "inferred_absent"
+    UNKNOWN = "unknown"
+    UNCODED = "uncoded"
+    DISPUTED = "disputed"
+    SUSPECTED_UNKNOWN = "suspected_unknown"
+
+
+@dataclass
+class ParsedValue:
+    """
+    A parsed Seshat data value with uncertainty information.
+
+    Attributes:
+        raw: Original string value from the dataset
+        value: Parsed numeric value or None
+        value_min: Lower bound of range (for uncertain values)
+        value_max: Upper bound of range (for uncertain values)
+        quality: Data quality indicator
+        is_inferred: Whether value was inferred
+        is_disputed: Whether value is disputed by experts
+        notes: Any additional notes or qualifiers
+    """
+
+    raw: str
+    value: float | None = None
+    value_min: float | None = None
+    value_max: float | None = None
+    quality: DataQuality = DataQuality.PRESENT
+    is_inferred: bool = False
+    is_disputed: bool = False
+    notes: str = ""
+
+
+@dataclass
+class Polity:
+    """
+    A Seshat polity (political entity).
+
+    Attributes:
+        id: Short identifier (e.g., "RomPrin")
+        name: Full name (e.g., "Roman Principate")
+        nga: Natural Geographic Area
+        start_year: Start year (CE, negative for BCE)
+        end_year: End year (CE, negative for BCE)
+        variables: Dictionary of variable name to parsed values
+    """
+
+    id: str
+    name: str
+    nga: str
+    start_year: int
+    end_year: int
+    variables: dict[str, list[ParsedValue]] = field(default_factory=dict)
+
+
+@dataclass
+class SeshatDataset:
+    """
+    Container for a parsed Seshat dataset.
+
+    Attributes:
+        polities: List of polity records
+        variables: List of variable names
+        df: Raw DataFrame for custom queries
+        metadata: Dataset metadata
+    """
+
+    polities: list[Polity]
+    variables: list[str]
+    df: pd.DataFrame
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+# Regex patterns for parsing values
+RANGE_PATTERN = re.compile(r"\[?\s*(-?\d+(?:\.\d+)?)\s*[-–]\s*(-?\d+(?:\.\d+)?)\s*\]?")
+NUMBER_PATTERN = re.compile(r"^(-?\d+(?:\.\d+)?)\s*$")
+INFERRED_PATTERN = re.compile(r"inferred\s+(present|absent)", re.IGNORECASE)
+
+
+def parse_value(raw: str | float | None) -> ParsedValue:
+    """
+    Parse a raw Seshat value into a structured ParsedValue.
+
+    Args:
+        raw: The raw value from the dataset (string, number, or None)
+
+    Returns:
+        ParsedValue with parsed numeric value and quality indicators
+
+    Examples:
+        >>> parse_value("present")
+        ParsedValue(raw='present', value=1.0, quality=DataQuality.PRESENT)
+
+        >>> parse_value("[100-500]")
+        ParsedValue(raw='[100-500]', value=300.0, value_min=100.0, value_max=500.0)
+
+        >>> parse_value("unknown")
+        ParsedValue(raw='unknown', value=None, quality=DataQuality.UNKNOWN)
+    """
+    # Handle None and NaN
+    if raw is None or (isinstance(raw, float) and pd.isna(raw)):
+        return ParsedValue(raw="", quality=DataQuality.UNCODED)
+
+    # Convert to string for processing
+    if isinstance(raw, (int, float)):
+        return ParsedValue(
+            raw=str(raw),
+            value=float(raw),
+            quality=DataQuality.PRESENT,
+        )
+
+    raw_str = str(raw).strip()
+
+    if not raw_str:
+        return ParsedValue(raw="", quality=DataQuality.UNCODED)
+
+    raw_lower = raw_str.lower()
+
+    # Check for quality indicators
+    if raw_lower == "present":
+        return ParsedValue(raw=raw_str, value=1.0, quality=DataQuality.PRESENT)
+
+    if raw_lower == "absent":
+        return ParsedValue(raw=raw_str, value=0.0, quality=DataQuality.ABSENT)
+
+    if raw_lower == "unknown":
+        return ParsedValue(raw=raw_str, quality=DataQuality.UNKNOWN)
+
+    if raw_lower == "uncoded":
+        return ParsedValue(raw=raw_str, quality=DataQuality.UNCODED)
+
+    if raw_lower == "suspected unknown":
+        return ParsedValue(raw=raw_str, quality=DataQuality.SUSPECTED_UNKNOWN)
+
+    # Check for inferred values
+    inferred_match = INFERRED_PATTERN.search(raw_str)
+    if inferred_match:
+        status = inferred_match.group(1).lower()
+        quality = (
+            DataQuality.INFERRED_PRESENT
+            if status == "present"
+            else DataQuality.INFERRED_ABSENT
+        )
+        return ParsedValue(
+            raw=raw_str,
+            value=1.0 if status == "present" else 0.0,
+            quality=quality,
+            is_inferred=True,
+        )
+
+    # Check for range values
+    range_match = RANGE_PATTERN.search(raw_str)
+    if range_match:
+        low = float(range_match.group(1))
+        high = float(range_match.group(2))
+        midpoint = (low + high) / 2
+        return ParsedValue(
+            raw=raw_str,
+            value=midpoint,
+            value_min=low,
+            value_max=high,
+            quality=DataQuality.PRESENT,
+        )
+
+    # Check for simple numeric value
+    number_match = NUMBER_PATTERN.match(raw_str)
+    if number_match:
+        return ParsedValue(
+            raw=raw_str,
+            value=float(number_match.group(1)),
+            quality=DataQuality.PRESENT,
+        )
+
+    # Check for disputed values
+    if "disputed" in raw_lower:
+        return ParsedValue(
+            raw=raw_str,
+            quality=DataQuality.DISPUTED,
+            is_disputed=True,
+        )
+
+    # Return as-is with notes
+    return ParsedValue(
+        raw=raw_str,
+        quality=DataQuality.PRESENT,
+        notes=raw_str,
+    )
+
+
+def load_seshat_excel(
+    filepath: Path | str,
+    sheet_name: str | int = 0,
+) -> pd.DataFrame:
+    """
+    Load a Seshat Excel file into a DataFrame.
+
+    Args:
+        filepath: Path to the Excel file
+        sheet_name: Sheet name or index to load (default: first sheet)
+
+    Returns:
+        DataFrame with the raw Seshat data
+
+    Raises:
+        FileNotFoundError: If the file doesn't exist
+        ValueError: If the file format is invalid
+    """
+    filepath = Path(filepath)
+    if not filepath.exists():
+        raise FileNotFoundError(f"Seshat data file not found: {filepath}")
+
+    logger.info(f"Loading Seshat data from: {filepath}")
+    df = pd.read_excel(filepath, sheet_name=sheet_name)
+    logger.info(f"Loaded {len(df)} rows, {len(df.columns)} columns")
+
+    return df
+
+
+def load_seshat_csv(filepath: Path | str) -> pd.DataFrame:
+    """
+    Load a Seshat CSV file into a DataFrame.
+
+    Args:
+        filepath: Path to the CSV file
+
+    Returns:
+        DataFrame with the raw Seshat data
+
+    Raises:
+        FileNotFoundError: If the file doesn't exist
+    """
+    filepath = Path(filepath)
+    if not filepath.exists():
+        raise FileNotFoundError(f"Seshat data file not found: {filepath}")
+
+    logger.info(f"Loading Seshat CSV from: {filepath}")
+
+    # Try different encodings
+    for encoding in ["utf-8", "latin-1", "cp1252"]:
+        try:
+            df = pd.read_csv(filepath, encoding=encoding)
+            logger.info(f"Loaded {len(df)} rows, {len(df.columns)} columns")
+            return df
+        except UnicodeDecodeError:
+            continue
+
+    raise ValueError(f"Could not read CSV file with any supported encoding: {filepath}")
+
+
+def parse_seshat_dataframe(
+    df: pd.DataFrame,
+    polity_col: str = "Polity",
+    name_col: str = "Original_name",
+    nga_col: str = "NGA",
+    start_col: str = "Start",
+    end_col: str = "End",
+) -> SeshatDataset:
+    """
+    Parse a Seshat DataFrame into structured Polity objects.
+
+    Args:
+        df: Raw DataFrame from load_seshat_excel or load_seshat_csv
+        polity_col: Column name for polity ID
+        name_col: Column name for polity name
+        nga_col: Column name for Natural Geographic Area
+        start_col: Column name for start year
+        end_col: Column name for end year
+
+    Returns:
+        SeshatDataset with parsed polities and metadata
+
+    Raises:
+        ValueError: If required columns are missing
+    """
+    # Verify required columns exist
+    required_cols = [polity_col, name_col, nga_col, start_col, end_col]
+
+    # Try to find columns with similar names (case-insensitive)
+    col_mapping = {}
+    for req_col in required_cols:
+        if req_col in df.columns:
+            col_mapping[req_col] = req_col
+        else:
+            # Look for case-insensitive match
+            for actual_col in df.columns:
+                if actual_col.lower() == req_col.lower():
+                    col_mapping[req_col] = actual_col
+                    break
+
+    # Check for still-missing columns
+    still_missing = [col for col in required_cols if col not in col_mapping]
+    if still_missing:
+        available = ", ".join(df.columns[:10].tolist())
+        raise ValueError(
+            f"Required columns not found: {still_missing}. "
+            f"Available columns (first 10): {available}..."
+        )
+
+    # Identify variable columns (everything except metadata columns)
+    metadata_cols = set(col_mapping.values())
+    variable_cols = [col for col in df.columns if col not in metadata_cols]
+
+    logger.info(f"Found {len(variable_cols)} variable columns")
+
+    # Parse each row into a Polity
+    polities = []
+    for _, row in df.iterrows():
+        polity_id = str(row[col_mapping[polity_col]])
+        name = str(row[col_mapping[name_col]])
+        nga = str(row[col_mapping[nga_col]])
+
+        # Parse years
+        start_raw = row[col_mapping[start_col]]
+        end_raw = row[col_mapping[end_col]]
+
+        try:
+            start_year = int(float(start_raw)) if pd.notna(start_raw) else 0
+        except (ValueError, TypeError):
+            start_year = 0
+
+        try:
+            end_year = int(float(end_raw)) if pd.notna(end_raw) else 0
+        except (ValueError, TypeError):
+            end_year = 0
+
+        # Parse variables
+        variables: dict[str, list[ParsedValue]] = {}
+        for var_col in variable_cols:
+            raw_value = row[var_col]
+            parsed = parse_value(raw_value)
+            variables[var_col] = [parsed]
+
+        polity = Polity(
+            id=polity_id,
+            name=name,
+            nga=nga,
+            start_year=start_year,
+            end_year=end_year,
+            variables=variables,
+        )
+        polities.append(polity)
+
+    logger.info(f"Parsed {len(polities)} polities")
+
+    return SeshatDataset(
+        polities=polities,
+        variables=variable_cols,
+        df=df,
+        metadata={
+            "source": "Seshat Equinox-2020",
+            "doi": "10.5281/zenodo.6642229",
+            "n_polities": len(polities),
+            "n_variables": len(variable_cols),
+        },
+    )
+
+
+def load_equinox(data_dir: Path | str | None = None) -> SeshatDataset:
+    """
+    Load the Seshat Equinox-2020 dataset.
+
+    This is the main entry point for loading Seshat data. It looks for
+    the downloaded Equinox dataset and parses it into structured format.
+
+    Args:
+        data_dir: Directory containing the downloaded data.
+                  Defaults to ./data/seshat/
+
+    Returns:
+        SeshatDataset with all polities and variables
+
+    Raises:
+        FileNotFoundError: If dataset is not downloaded
+
+    Example:
+        >>> from cliodynamics.data.parser import load_equinox
+        >>> dataset = load_equinox()
+        >>> print(f"Loaded {len(dataset.polities)} polities")
+        Loaded 373 polities
+    """
+    if data_dir is None:
+        # Look in default location relative to project root
+        module_path = Path(__file__).resolve()
+        src_path = module_path.parent.parent.parent
+        project_root = src_path.parent
+        data_dir = project_root / "data" / "seshat"
+    else:
+        data_dir = Path(data_dir)
+
+    if not data_dir.exists():
+        raise FileNotFoundError(
+            f"Seshat data directory not found: {data_dir}. "
+            "Run 'python -m cliodynamics.data.download' first."
+        )
+
+    # Look for Excel file first, then CSV
+    excel_files = list(data_dir.glob("*.xlsx"))
+    csv_files = list(data_dir.glob("*.csv"))
+
+    if excel_files:
+        filepath = excel_files[0]
+        df = load_seshat_excel(filepath)
+    elif csv_files:
+        filepath = csv_files[0]
+        df = load_seshat_csv(filepath)
+    else:
+        raise FileNotFoundError(
+            f"No Excel or CSV files found in {data_dir}. "
+            "Run 'python -m cliodynamics.data.download' first."
+        )
+
+    return parse_seshat_dataframe(df)
+
+
+def get_variable_summary(dataset: SeshatDataset, variable: str) -> dict[str, Any]:
+    """
+    Get summary statistics for a variable across all polities.
+
+    Args:
+        dataset: Loaded SeshatDataset
+        variable: Variable name to summarize
+
+    Returns:
+        Dictionary with count, mean, min, max, and quality distribution
+
+    Raises:
+        KeyError: If variable is not in dataset
+    """
+    if variable not in dataset.variables:
+        raise KeyError(f"Variable '{variable}' not found in dataset")
+
+    values = []
+    quality_counts: dict[str, int] = {}
+
+    for polity in dataset.polities:
+        if variable in polity.variables:
+            for pv in polity.variables[variable]:
+                quality_name = pv.quality.value
+                quality_counts[quality_name] = quality_counts.get(quality_name, 0) + 1
+
+                if pv.value is not None:
+                    values.append(pv.value)
+
+    return {
+        "variable": variable,
+        "n_values": len(values),
+        "n_polities": len(dataset.polities),
+        "mean": sum(values) / len(values) if values else None,
+        "min": min(values) if values else None,
+        "max": max(values) if values else None,
+        "quality_distribution": quality_counts,
+    }

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,593 @@
+"""
+Unit tests for the cliodynamics.data module.
+
+Tests parsing logic, edge cases, and data quality indicators.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from cliodynamics.data.parser import (
+    DataQuality,
+    ParsedValue,
+    Polity,
+    SeshatDataset,
+    get_variable_summary,
+    parse_seshat_dataframe,
+    parse_value,
+)
+
+
+class TestParseValue:
+    """Tests for the parse_value function."""
+
+    def test_parse_none(self):
+        """Test parsing None values."""
+        result = parse_value(None)
+        assert result.quality == DataQuality.UNCODED
+        assert result.value is None
+        assert result.raw == ""
+
+    def test_parse_nan(self):
+        """Test parsing NaN values."""
+        result = parse_value(float("nan"))
+        assert result.quality == DataQuality.UNCODED
+        assert result.value is None
+
+    def test_parse_empty_string(self):
+        """Test parsing empty strings."""
+        result = parse_value("")
+        assert result.quality == DataQuality.UNCODED
+        assert result.value is None
+
+    def test_parse_whitespace_string(self):
+        """Test parsing whitespace-only strings."""
+        result = parse_value("   ")
+        assert result.quality == DataQuality.UNCODED
+        assert result.value is None
+
+    def test_parse_present(self):
+        """Test parsing 'present' values."""
+        result = parse_value("present")
+        assert result.quality == DataQuality.PRESENT
+        assert result.value == 1.0
+        assert result.raw == "present"
+
+    def test_parse_present_case_insensitive(self):
+        """Test parsing 'PRESENT' values (case insensitive)."""
+        result = parse_value("PRESENT")
+        assert result.quality == DataQuality.PRESENT
+        assert result.value == 1.0
+
+    def test_parse_absent(self):
+        """Test parsing 'absent' values."""
+        result = parse_value("absent")
+        assert result.quality == DataQuality.ABSENT
+        assert result.value == 0.0
+
+    def test_parse_unknown(self):
+        """Test parsing 'unknown' values."""
+        result = parse_value("unknown")
+        assert result.quality == DataQuality.UNKNOWN
+        assert result.value is None
+
+    def test_parse_uncoded(self):
+        """Test parsing 'uncoded' values."""
+        result = parse_value("uncoded")
+        assert result.quality == DataQuality.UNCODED
+        assert result.value is None
+
+    def test_parse_suspected_unknown(self):
+        """Test parsing 'suspected unknown' values."""
+        result = parse_value("suspected unknown")
+        assert result.quality == DataQuality.SUSPECTED_UNKNOWN
+        assert result.value is None
+
+    def test_parse_inferred_present(self):
+        """Test parsing 'inferred present' values."""
+        result = parse_value("inferred present")
+        assert result.quality == DataQuality.INFERRED_PRESENT
+        assert result.value == 1.0
+        assert result.is_inferred is True
+
+    def test_parse_inferred_absent(self):
+        """Test parsing 'inferred absent' values."""
+        result = parse_value("inferred absent")
+        assert result.quality == DataQuality.INFERRED_ABSENT
+        assert result.value == 0.0
+        assert result.is_inferred is True
+
+    def test_parse_integer(self):
+        """Test parsing integer values."""
+        result = parse_value(100)
+        assert result.value == 100.0
+        assert result.quality == DataQuality.PRESENT
+
+    def test_parse_float(self):
+        """Test parsing float values."""
+        result = parse_value(3.14159)
+        assert result.value == 3.14159
+        assert result.quality == DataQuality.PRESENT
+
+    def test_parse_negative_number(self):
+        """Test parsing negative numbers (e.g., BCE years)."""
+        result = parse_value(-500)
+        assert result.value == -500.0
+        assert result.quality == DataQuality.PRESENT
+
+    def test_parse_string_number(self):
+        """Test parsing numeric strings."""
+        result = parse_value("1000")
+        assert result.value == 1000.0
+        assert result.quality == DataQuality.PRESENT
+
+    def test_parse_string_negative_number(self):
+        """Test parsing negative numeric strings."""
+        result = parse_value("-500")
+        assert result.value == -500.0
+
+    def test_parse_string_float(self):
+        """Test parsing float strings."""
+        result = parse_value("123.456")
+        assert result.value == 123.456
+
+    def test_parse_range_brackets(self):
+        """Test parsing range values with brackets [X-Y]."""
+        result = parse_value("[100-500]")
+        assert result.value == 300.0  # Midpoint
+        assert result.value_min == 100.0
+        assert result.value_max == 500.0
+        assert result.quality == DataQuality.PRESENT
+
+    def test_parse_range_no_brackets(self):
+        """Test parsing range values without brackets."""
+        result = parse_value("100-500")
+        assert result.value == 300.0
+        assert result.value_min == 100.0
+        assert result.value_max == 500.0
+
+    def test_parse_range_with_spaces(self):
+        """Test parsing range values with spaces."""
+        result = parse_value("[ 100 - 500 ]")
+        assert result.value == 300.0
+        assert result.value_min == 100.0
+        assert result.value_max == 500.0
+
+    def test_parse_range_floats(self):
+        """Test parsing range with float values."""
+        result = parse_value("[1.5-3.5]")
+        assert result.value == 2.5
+        assert result.value_min == 1.5
+        assert result.value_max == 3.5
+
+    def test_parse_range_negative(self):
+        """Test parsing range with negative values."""
+        result = parse_value("[-500--300]")
+        assert result.value == -400.0
+        assert result.value_min == -500.0
+        assert result.value_max == -300.0
+
+    def test_parse_disputed(self):
+        """Test parsing 'disputed' values."""
+        result = parse_value("disputed")
+        assert result.quality == DataQuality.DISPUTED
+        assert result.is_disputed is True
+
+    def test_parse_text_with_disputed(self):
+        """Test parsing text containing 'disputed'."""
+        result = parse_value("value disputed by experts")
+        assert result.quality == DataQuality.DISPUTED
+        assert result.is_disputed is True
+
+    def test_parse_arbitrary_text(self):
+        """Test parsing arbitrary text values."""
+        result = parse_value("some descriptive text")
+        assert result.quality == DataQuality.PRESENT
+        assert result.notes == "some descriptive text"
+        assert result.value is None
+
+
+class TestParsedValue:
+    """Tests for the ParsedValue dataclass."""
+
+    def test_defaults(self):
+        """Test default values."""
+        pv = ParsedValue(raw="test")
+        assert pv.value is None
+        assert pv.value_min is None
+        assert pv.value_max is None
+        assert pv.quality == DataQuality.PRESENT
+        assert pv.is_inferred is False
+        assert pv.is_disputed is False
+        assert pv.notes == ""
+
+    def test_with_range(self):
+        """Test ParsedValue with range values."""
+        pv = ParsedValue(
+            raw="[100-500]",
+            value=300.0,
+            value_min=100.0,
+            value_max=500.0,
+        )
+        assert pv.value == 300.0
+        assert pv.value_min == 100.0
+        assert pv.value_max == 500.0
+
+
+class TestPolity:
+    """Tests for the Polity dataclass."""
+
+    def test_create_polity(self):
+        """Test creating a basic polity."""
+        polity = Polity(
+            id="RomPrin",
+            name="Roman Principate",
+            nga="Italy",
+            start_year=-27,
+            end_year=284,
+        )
+        assert polity.id == "RomPrin"
+        assert polity.name == "Roman Principate"
+        assert polity.nga == "Italy"
+        assert polity.start_year == -27
+        assert polity.end_year == 284
+        assert polity.variables == {}
+
+    def test_polity_with_variables(self):
+        """Test polity with variables."""
+        polity = Polity(
+            id="Test",
+            name="Test Polity",
+            nga="Test NGA",
+            start_year=0,
+            end_year=100,
+            variables={
+                "population": [ParsedValue(raw="1000000", value=1000000.0)],
+            },
+        )
+        assert "population" in polity.variables
+        assert polity.variables["population"][0].value == 1000000.0
+
+
+class TestSeshatDataset:
+    """Tests for the SeshatDataset dataclass."""
+
+    def test_create_empty_dataset(self):
+        """Test creating an empty dataset."""
+        df = pd.DataFrame()
+        dataset = SeshatDataset(
+            polities=[],
+            variables=[],
+            df=df,
+        )
+        assert len(dataset.polities) == 0
+        assert len(dataset.variables) == 0
+        assert dataset.metadata == {}
+
+    def test_dataset_with_metadata(self):
+        """Test dataset with metadata."""
+        df = pd.DataFrame()
+        dataset = SeshatDataset(
+            polities=[],
+            variables=[],
+            df=df,
+            metadata={"source": "test", "version": "1.0"},
+        )
+        assert dataset.metadata["source"] == "test"
+        assert dataset.metadata["version"] == "1.0"
+
+
+class TestParseSeshatDataframe:
+    """Tests for parse_seshat_dataframe function."""
+
+    def test_parse_simple_dataframe(self):
+        """Test parsing a simple DataFrame."""
+        df = pd.DataFrame(
+            {
+                "Polity": ["RomPrin", "RomDom"],
+                "Original_name": ["Roman Principate", "Roman Dominate"],
+                "NGA": ["Italy", "Italy"],
+                "Start": [-27, 284],
+                "End": [284, 476],
+                "Population": [50000000, 30000000],
+            }
+        )
+
+        dataset = parse_seshat_dataframe(df)
+
+        assert len(dataset.polities) == 2
+        assert dataset.polities[0].id == "RomPrin"
+        assert dataset.polities[0].name == "Roman Principate"
+        assert dataset.polities[0].start_year == -27
+        assert dataset.polities[0].end_year == 284
+        assert "Population" in dataset.polities[0].variables
+
+    def test_parse_with_missing_values(self):
+        """Test parsing DataFrame with missing values."""
+        df = pd.DataFrame(
+            {
+                "Polity": ["Test1", "Test2"],
+                "Original_name": ["Test Polity 1", "Test Polity 2"],
+                "NGA": ["Region 1", "Region 2"],
+                "Start": [0, 100],
+                "End": [100, 200],
+                "Variable1": ["present", None],
+                "Variable2": [100, "unknown"],
+            }
+        )
+
+        dataset = parse_seshat_dataframe(df)
+
+        assert len(dataset.polities) == 2
+        # First polity has "present"
+        v1_p1 = dataset.polities[0].variables["Variable1"][0]
+        assert v1_p1.quality == DataQuality.PRESENT
+        assert v1_p1.value == 1.0
+
+        # Second polity has None (uncoded)
+        v1_p2 = dataset.polities[1].variables["Variable1"][0]
+        assert v1_p2.quality == DataQuality.UNCODED
+
+        # Second polity has "unknown" for Variable2
+        v2_p2 = dataset.polities[1].variables["Variable2"][0]
+        assert v2_p2.quality == DataQuality.UNKNOWN
+
+    def test_parse_case_insensitive_columns(self):
+        """Test parsing with case-insensitive column matching."""
+        df = pd.DataFrame(
+            {
+                "polity": ["Test"],  # lowercase
+                "original_name": ["Test Polity"],  # lowercase
+                "nga": ["Region"],  # lowercase
+                "start": [0],  # lowercase
+                "end": [100],  # lowercase
+            }
+        )
+
+        dataset = parse_seshat_dataframe(df)
+        assert len(dataset.polities) == 1
+        assert dataset.polities[0].id == "Test"
+
+    def test_parse_missing_required_columns(self):
+        """Test error when required columns are missing."""
+        df = pd.DataFrame(
+            {
+                "SomeOtherColumn": [1, 2, 3],
+            }
+        )
+
+        with pytest.raises(ValueError, match="Required columns not found"):
+            parse_seshat_dataframe(df)
+
+    def test_parse_identifies_variables(self):
+        """Test that variable columns are correctly identified."""
+        df = pd.DataFrame(
+            {
+                "Polity": ["Test"],
+                "Original_name": ["Test Polity"],
+                "NGA": ["Region"],
+                "Start": [0],
+                "End": [100],
+                "Var1": ["present"],
+                "Var2": [100],
+                "Var3": ["[10-20]"],
+            }
+        )
+
+        dataset = parse_seshat_dataframe(df)
+
+        # Should have 3 variables (not counting metadata columns)
+        assert len(dataset.variables) == 3
+        assert "Var1" in dataset.variables
+        assert "Var2" in dataset.variables
+        assert "Var3" in dataset.variables
+
+
+class TestGetVariableSummary:
+    """Tests for get_variable_summary function."""
+
+    def test_summary_numeric_variable(self):
+        """Test summary for a numeric variable."""
+        polities = [
+            Polity(
+                id=f"P{i}",
+                name=f"Polity {i}",
+                nga="Region",
+                start_year=0,
+                end_year=100,
+                variables={"Population": [ParsedValue(raw=str(v), value=float(v))]},
+            )
+            for i, v in enumerate([100, 200, 300, 400, 500])
+        ]
+        df = pd.DataFrame()
+        dataset = SeshatDataset(
+            polities=polities,
+            variables=["Population"],
+            df=df,
+        )
+
+        summary = get_variable_summary(dataset, "Population")
+
+        assert summary["variable"] == "Population"
+        assert summary["n_values"] == 5
+        assert summary["mean"] == 300.0
+        assert summary["min"] == 100.0
+        assert summary["max"] == 500.0
+
+    def test_summary_with_missing_values(self):
+        """Test summary handles missing values correctly."""
+        polities = [
+            Polity(
+                id="P1",
+                name="Polity 1",
+                nga="Region",
+                start_year=0,
+                end_year=100,
+                variables={"Var": [ParsedValue(raw="100", value=100.0)]},
+            ),
+            Polity(
+                id="P2",
+                name="Polity 2",
+                nga="Region",
+                start_year=0,
+                end_year=100,
+                variables={
+                    "Var": [ParsedValue(raw="unknown", quality=DataQuality.UNKNOWN)]
+                },
+            ),
+        ]
+        df = pd.DataFrame()
+        dataset = SeshatDataset(
+            polities=polities,
+            variables=["Var"],
+            df=df,
+        )
+
+        summary = get_variable_summary(dataset, "Var")
+
+        # Only 1 numeric value
+        assert summary["n_values"] == 1
+        assert summary["n_polities"] == 2
+        # Quality distribution should show both
+        assert "present" in summary["quality_distribution"]
+        assert "unknown" in summary["quality_distribution"]
+
+    def test_summary_unknown_variable(self):
+        """Test error for unknown variable."""
+        df = pd.DataFrame()
+        dataset = SeshatDataset(
+            polities=[],
+            variables=["KnownVar"],
+            df=df,
+        )
+
+        with pytest.raises(KeyError, match="Variable 'UnknownVar' not found"):
+            get_variable_summary(dataset, "UnknownVar")
+
+
+class TestDataQuality:
+    """Tests for DataQuality enum."""
+
+    def test_quality_values(self):
+        """Test all quality values exist."""
+        assert DataQuality.PRESENT.value == "present"
+        assert DataQuality.ABSENT.value == "absent"
+        assert DataQuality.INFERRED_PRESENT.value == "inferred_present"
+        assert DataQuality.INFERRED_ABSENT.value == "inferred_absent"
+        assert DataQuality.UNKNOWN.value == "unknown"
+        assert DataQuality.UNCODED.value == "uncoded"
+        assert DataQuality.DISPUTED.value == "disputed"
+        assert DataQuality.SUSPECTED_UNKNOWN.value == "suspected_unknown"
+
+
+class TestDownloadModule:
+    """Tests for the download module."""
+
+    def test_import_download_functions(self):
+        """Test that download functions can be imported."""
+        from cliodynamics.data.download import (
+            download_and_extract,
+            get_zenodo_download_url,
+        )
+
+        assert callable(download_and_extract)
+        assert callable(get_zenodo_download_url)
+
+    @patch("cliodynamics.data.download.requests.get")
+    def test_get_zenodo_download_url(self, mock_get):
+        """Test fetching download URL from Zenodo API."""
+        from cliodynamics.data.download import get_zenodo_download_url
+
+        # Mock the API response
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "files": [
+                {
+                    "key": "seshatdb/Equinox_Data-v.1.zip",
+                    "links": {"self": "https://zenodo.org/api/files/test.zip"},
+                }
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        url = get_zenodo_download_url()
+        assert url == "https://zenodo.org/api/files/test.zip"
+
+    @patch("cliodynamics.data.download.requests.get")
+    def test_get_zenodo_download_url_no_files(self, mock_get):
+        """Test error when no files in Zenodo record."""
+        from cliodynamics.data.download import get_zenodo_download_url
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"files": []}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        with pytest.raises(ValueError, match="No files found"):
+            get_zenodo_download_url()
+
+
+class TestEdgeCases:
+    """Tests for edge cases and special scenarios."""
+
+    def test_parse_unicode_dash_in_range(self):
+        """Test parsing range with unicode en-dash."""
+        result = parse_value("[100\u2013500]")  # en-dash
+        assert result.value == 300.0
+        assert result.value_min == 100.0
+        assert result.value_max == 500.0
+
+    def test_parse_very_large_number(self):
+        """Test parsing very large numbers."""
+        result = parse_value(1e12)
+        assert result.value == 1e12
+
+    def test_parse_very_small_number(self):
+        """Test parsing very small numbers."""
+        result = parse_value(0.00001)
+        assert result.value == 0.00001
+
+    def test_parse_zero(self):
+        """Test parsing zero."""
+        result = parse_value(0)
+        assert result.value == 0.0
+        assert result.quality == DataQuality.PRESENT
+
+    def test_parse_string_zero(self):
+        """Test parsing string zero."""
+        result = parse_value("0")
+        assert result.value == 0.0
+
+    def test_polity_negative_bce_years(self):
+        """Test polity with BCE (negative) years."""
+        df = pd.DataFrame(
+            {
+                "Polity": ["AncientCiv"],
+                "Original_name": ["Ancient Civilization"],
+                "NGA": ["Middle East"],
+                "Start": [-3000],
+                "End": [-1000],
+            }
+        )
+
+        dataset = parse_seshat_dataframe(df)
+        polity = dataset.polities[0]
+
+        assert polity.start_year == -3000
+        assert polity.end_year == -1000
+
+    def test_inferred_present_various_formats(self):
+        """Test various formats of 'inferred present'."""
+        variants = [
+            "inferred present",
+            "Inferred Present",
+            "INFERRED PRESENT",
+            "inferred  present",  # extra space
+        ]
+        for variant in variants:
+            result = parse_value(variant)
+            assert result.is_inferred is True, f"Failed for: {variant}"
+            assert result.value == 1.0, f"Failed for: {variant}"


### PR DESCRIPTION
## Summary
- Create `src/cliodynamics/data/download.py` - Script to download Seshat Equinox-2020 from Zenodo
- Create `src/cliodynamics/data/parser.py` - Parse raw CSV/Excel into Python data structures
- Add `requests` and `openpyxl` dependencies to `pyproject.toml`
- Document schema: polities, variables, temporal encoding (BCE as negative years)
- Handle Seshat-specific conventions (uncertainty markers, missing data codes)
- 51 unit tests for parsing edge cases in `tests/test_data.py`

## Key Features

### Download Module
- Fetches Equinox-2020 from Zenodo API (DOI: 10.5281/zenodo.6642229)
- Extracts to `data/seshat/` directory
- Usage: `python -m cliodynamics.data.download`

### Parser Module
- `ParsedValue` dataclass with uncertainty support (ranges, quality indicators)
- `Polity` dataclass for political entities with temporal bounds
- `SeshatDataset` container with metadata
- Handles: present/absent, inferred values, unknown/uncoded, disputed, numeric ranges

### Data Conventions Supported
- Binary: `present`, `absent`, `inferred present`, `inferred absent`
- Missing: `unknown`, `uncoded`, `suspected unknown`
- Uncertainty: `[X-Y]` range notation, `disputed`
- Temporal: CE years (negative = BCE)

## Test Plan
- [x] All 54 tests pass (`pytest tests/`)
- [x] Ruff linting clean (`ruff check`)
- [x] Code formatted (`ruff format`)
- [ ] Manual test: `python -m cliodynamics.data.download` fetches dataset

Closes #2

---
Generated with [Claude Code](https://claude.com/claude-code)