### PR TITLE
Add Polaris-2025 dataset download and integration

### DIFF
--- a/src/cliodynamics/data/__init__.py
+++ b/src/cliodynamics/data/__init__.py
@@ -46,6 +46,8 @@ Usage (API client - requires seshat_api package):
 """
 
 from cliodynamics.data.access import (
+    DATASET_EQUINOX,
+    DATASET_POLARIS,
     VARIABLE_ALIASES,
     VARIABLE_CATEGORIES,
     PolityTimeSeries,
@@ -62,6 +64,7 @@ from cliodynamics.data.api_client import (
     SeshatAPINotInstalledError,
 )
 from cliodynamics.data.download import download_and_extract, get_zenodo_download_url
+from cliodynamics.data.download_polaris import download_polaris
 from cliodynamics.data.parser import (
     DataQuality,
     ParsedValue,
@@ -69,6 +72,8 @@ from cliodynamics.data.parser import (
     SeshatDataset,
     get_variable_summary,
     load_equinox,
+    load_polaris,
+    load_polaris_threads,
     load_seshat_csv,
     load_seshat_excel,
     parse_seshat_dataframe,
@@ -82,6 +87,8 @@ __all__ = [
     "TimeSeriesPoint",
     "VARIABLE_ALIASES",
     "VARIABLE_CATEGORIES",
+    "DATASET_EQUINOX",
+    "DATASET_POLARIS",
     # API client classes
     "SeshatAPIClient",
     "PolityInfo",
@@ -93,6 +100,7 @@ __all__ = [
     # Download functions
     "download_and_extract",
     "get_zenodo_download_url",
+    "download_polaris",
     # Parser classes
     "DataQuality",
     "ParsedValue",
@@ -101,6 +109,8 @@ __all__ = [
     # Parser functions
     "get_variable_summary",
     "load_equinox",
+    "load_polaris",
+    "load_polaris_threads",
     "load_seshat_csv",
     "load_seshat_excel",
     "parse_seshat_dataframe",

--- a/src/cliodynamics/data/download_polaris.py
+++ b/src/cliodynamics/data/download_polaris.py
@@ -1,0 +1,176 @@
+"""
+Download Seshat Polaris-2025 dataset from GitHub.
+
+The Polaris-2025 dataset is the latest release from the Seshat Global History
+Databank, providing updated and expanded coverage compared to Equinox-2020.
+
+Dataset Repository: https://github.com/Seshat-Global-History-Databank/build_polaris_dataset
+License: CC-BY-NC-SA
+
+Key Differences from Equinox-2020:
+    - Polaris-2025 is built from the live Seshat API, providing more recent data
+    - Includes polity_threads.csv for polity temporal continuity information
+    - Column naming may differ from Equinox-2020 (lowercase vs mixed case)
+    - Expanded variable coverage
+
+Usage:
+    python -m cliodynamics.data.download_polaris
+
+This will download the dataset to the data/polaris2025/ directory.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import requests
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# GitHub raw URLs for Polaris-2025 dataset files
+POLARIS_EXCEL_URL = (
+    "https://raw.githubusercontent.com/Seshat-Global-History-Databank/"
+    "build_polaris_dataset/main/Polaris2025.xlsx"
+)
+POLARIS_THREADS_URL = (
+    "https://raw.githubusercontent.com/Seshat-Global-History-Databank/"
+    "build_polaris_dataset/main/polity_threads.csv"
+)
+
+# Expected filenames
+EXPECTED_EXCEL_FILE = "Polaris2025.xlsx"
+EXPECTED_THREADS_FILE = "polity_threads.csv"
+
+# Default download directory (relative to project root)
+DEFAULT_DATA_DIR = Path("data")
+
+
+def download_file(url: str, dest_path: Path, timeout: int = 300) -> None:
+    """
+    Download a file from URL to destination path.
+
+    Args:
+        url: URL to download from
+        dest_path: Local path to save the file
+        timeout: Request timeout in seconds
+
+    Raises:
+        requests.HTTPError: If download fails
+    """
+    logger.info(f"Downloading: {url}")
+    response = requests.get(url, stream=True, timeout=timeout)
+    response.raise_for_status()
+
+    # Get total size for progress reporting
+    total_size = int(response.headers.get("content-length", 0))
+    if total_size > 0:
+        logger.info(f"File size: {total_size / 1024 / 1024:.2f} MB")
+
+    # Write to file
+    downloaded = 0
+    with dest_path.open("wb") as f:
+        for chunk in response.iter_content(chunk_size=8192):
+            f.write(chunk)
+            downloaded += len(chunk)
+            if total_size > 0:
+                pct = downloaded / total_size * 100
+                logger.debug(f"Downloaded {pct:.1f}%")
+
+    logger.info(f"Saved to: {dest_path}")
+
+
+def download_polaris(
+    data_dir: Path | str | None = None,
+    force: bool = False,
+    include_threads: bool = True,
+) -> Path:
+    """
+    Download the Seshat Polaris-2025 dataset from GitHub.
+
+    Downloads the main Polaris2025.xlsx file and optionally the polity_threads.csv
+    file containing polity temporal continuity information.
+
+    Args:
+        data_dir: Directory to store the downloaded data. Defaults to ./data/
+        force: If True, re-download even if files already exist.
+        include_threads: If True, also download polity_threads.csv (default: True)
+
+    Returns:
+        Path to the data directory containing the downloaded files.
+
+    Raises:
+        requests.HTTPError: If download fails.
+
+    Example:
+        >>> from cliodynamics.data.download_polaris import download_polaris
+        >>> data_path = download_polaris()
+        >>> print(data_path)
+        data/polaris2025
+    """
+    if data_dir is None:
+        data_dir = DEFAULT_DATA_DIR
+    else:
+        data_dir = Path(data_dir)
+
+    # Create output directory
+    polaris_dir = data_dir / "polaris2025"
+    polaris_dir.mkdir(parents=True, exist_ok=True)
+
+    # Download Excel file
+    excel_path = polaris_dir / EXPECTED_EXCEL_FILE
+    if excel_path.exists() and not force:
+        logger.info(f"Excel file already exists: {excel_path}")
+    else:
+        download_file(POLARIS_EXCEL_URL, excel_path)
+
+    # Download polity threads file
+    if include_threads:
+        threads_path = polaris_dir / EXPECTED_THREADS_FILE
+        if threads_path.exists() and not force:
+            logger.info(f"Threads file already exists: {threads_path}")
+        else:
+            download_file(POLARIS_THREADS_URL, threads_path)
+
+    logger.info(f"Download complete. Data stored in: {polaris_dir}")
+    return polaris_dir
+
+
+def main() -> None:
+    """Main entry point for command-line usage."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    # Find project root (go up from this file)
+    # This module is at: src/cliodynamics/data/download_polaris.py
+    # Project root has: pyproject.toml, data/
+    module_path = Path(__file__).resolve()
+    src_path = module_path.parent.parent.parent  # up from data/ to src/
+    project_root = src_path.parent  # up from src/ to project root
+
+    data_dir = project_root / "data"
+    logger.info(f"Data directory: {data_dir}")
+
+    try:
+        output_path = download_polaris(data_dir)
+        print(f"\nSeshat Polaris-2025 dataset downloaded to: {output_path}")
+        print("\nAvailable files:")
+        for f in sorted(output_path.iterdir()):
+            size_mb = f.stat().st_size / 1024 / 1024
+            print(f"  {f.name} ({size_mb:.2f} MB)")
+    except requests.HTTPError as e:
+        logger.error(f"Download failed: {e}")
+        raise SystemExit(1) from e
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        raise SystemExit(1) from e
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/data/test_download_polaris.py
+++ b/tests/data/test_download_polaris.py
@@ -1,0 +1,196 @@
+"""
+Tests for the Polaris-2025 download module.
+
+Tests use mocking to avoid actual network requests during testing.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cliodynamics.data.download_polaris import (
+    EXPECTED_EXCEL_FILE,
+    EXPECTED_THREADS_FILE,
+    POLARIS_EXCEL_URL,
+    POLARIS_THREADS_URL,
+    download_file,
+    download_polaris,
+)
+
+
+class TestDownloadFile:
+    """Tests for the download_file function."""
+
+    @patch("cliodynamics.data.download_polaris.requests.get")
+    def test_download_file_success(self, mock_get: MagicMock) -> None:
+        """Test successful file download."""
+        # Mock response
+        mock_response = MagicMock()
+        mock_response.headers = {"content-length": "100"}
+        mock_response.iter_content.return_value = [b"test data"]
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dest_path = Path(tmpdir) / "test_file.txt"
+            download_file("https://example.com/file.txt", dest_path)
+
+            assert dest_path.exists()
+            assert dest_path.read_bytes() == b"test data"
+
+    @patch("cliodynamics.data.download_polaris.requests.get")
+    def test_download_file_http_error(self, mock_get: MagicMock) -> None:
+        """Test handling of HTTP errors."""
+        import requests
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.HTTPError("404 Not Found")
+        mock_get.return_value = mock_response
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dest_path = Path(tmpdir) / "test_file.txt"
+            with pytest.raises(requests.HTTPError):
+                download_file("https://example.com/notfound.txt", dest_path)
+
+
+class TestDownloadPolaris:
+    """Tests for the download_polaris function."""
+
+    @patch("cliodynamics.data.download_polaris.download_file")
+    def test_download_polaris_creates_directory(
+        self, mock_download_file: MagicMock
+    ) -> None:
+        """Test that download_polaris creates the data directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_dir = Path(tmpdir)
+            result = download_polaris(data_dir)
+
+            polaris_dir = data_dir / "polaris2025"
+            assert polaris_dir.exists()
+            assert result == polaris_dir
+
+    @patch("cliodynamics.data.download_polaris.download_file")
+    def test_download_polaris_downloads_files(
+        self, mock_download_file: MagicMock
+    ) -> None:
+        """Test that download_polaris downloads both files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_dir = Path(tmpdir)
+            download_polaris(data_dir, include_threads=True)
+
+            # Should have called download_file twice
+            assert mock_download_file.call_count == 2
+
+            # Check correct URLs were called
+            call_args = [call[0] for call in mock_download_file.call_args_list]
+            urls = [args[0] for args in call_args]
+            assert POLARIS_EXCEL_URL in urls
+            assert POLARIS_THREADS_URL in urls
+
+    @patch("cliodynamics.data.download_polaris.download_file")
+    def test_download_polaris_skips_existing(
+        self, mock_download_file: MagicMock
+    ) -> None:
+        """Test that download_polaris skips existing files without force."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_dir = Path(tmpdir)
+            polaris_dir = data_dir / "polaris2025"
+            polaris_dir.mkdir(parents=True)
+
+            # Create existing files
+            (polaris_dir / EXPECTED_EXCEL_FILE).write_bytes(b"existing data")
+            (polaris_dir / EXPECTED_THREADS_FILE).write_bytes(b"existing threads")
+
+            download_polaris(data_dir, force=False)
+
+            # Should not have called download_file
+            mock_download_file.assert_not_called()
+
+    @patch("cliodynamics.data.download_polaris.download_file")
+    def test_download_polaris_force_redownload(
+        self, mock_download_file: MagicMock
+    ) -> None:
+        """Test that download_polaris redownloads with force=True."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_dir = Path(tmpdir)
+            polaris_dir = data_dir / "polaris2025"
+            polaris_dir.mkdir(parents=True)
+
+            # Create existing files
+            (polaris_dir / EXPECTED_EXCEL_FILE).write_bytes(b"existing data")
+            (polaris_dir / EXPECTED_THREADS_FILE).write_bytes(b"existing threads")
+
+            download_polaris(data_dir, force=True)
+
+            # Should have called download_file twice
+            assert mock_download_file.call_count == 2
+
+    @patch("cliodynamics.data.download_polaris.download_file")
+    def test_download_polaris_without_threads(
+        self, mock_download_file: MagicMock
+    ) -> None:
+        """Test downloading without threads file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_dir = Path(tmpdir)
+            download_polaris(data_dir, include_threads=False)
+
+            # Should have called download_file once (Excel only)
+            assert mock_download_file.call_count == 1
+
+            # Check only Excel URL was called
+            call_args = mock_download_file.call_args_list[0][0]
+            assert call_args[0] == POLARIS_EXCEL_URL
+
+
+class TestDownloadPolarisURLs:
+    """Tests to verify correct URLs are used."""
+
+    def test_excel_url_format(self) -> None:
+        """Test that Excel URL is correctly formatted."""
+        assert "Polaris2025.xlsx" in POLARIS_EXCEL_URL
+        assert "github" in POLARIS_EXCEL_URL.lower()
+        assert "raw" in POLARIS_EXCEL_URL
+
+    def test_threads_url_format(self) -> None:
+        """Test that threads URL is correctly formatted."""
+        assert "polity_threads.csv" in POLARIS_THREADS_URL
+        assert "github" in POLARIS_THREADS_URL.lower()
+        assert "raw" in POLARIS_THREADS_URL
+
+
+class TestExpectedFiles:
+    """Tests for expected file constants."""
+
+    def test_expected_excel_file(self) -> None:
+        """Test expected Excel filename."""
+        assert EXPECTED_EXCEL_FILE == "Polaris2025.xlsx"
+
+    def test_expected_threads_file(self) -> None:
+        """Test expected threads filename."""
+        assert EXPECTED_THREADS_FILE == "polity_threads.csv"
+
+
+class TestModuleImports:
+    """Tests for module imports."""
+
+    def test_import_from_package(self) -> None:
+        """Test that download_polaris can be imported from package."""
+        from cliodynamics.data import download_polaris as dp
+
+        assert callable(dp)
+
+    def test_import_download_function(self) -> None:
+        """Test that download function is importable."""
+        from cliodynamics.data.download_polaris import download_polaris
+
+        assert callable(download_polaris)
+
+    def test_import_download_file(self) -> None:
+        """Test that download_file helper is importable."""
+        from cliodynamics.data.download_polaris import download_file
+
+        assert callable(download_file)

--- a/tests/data/test_polaris.py
+++ b/tests/data/test_polaris.py
@@ -1,0 +1,395 @@
+"""
+Tests for Polaris-2025 dataset parsing and SeshatDB integration.
+
+Tests the parser functions and SeshatDB dataset selection features.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from cliodynamics.data.access import (
+    DATASET_EQUINOX,
+    DATASET_POLARIS,
+    SeshatDB,
+)
+from cliodynamics.data.parser import (
+    load_polaris,
+    load_polaris_threads,
+    parse_seshat_dataframe,
+)
+
+
+class TestLoadPolaris:
+    """Tests for the load_polaris function."""
+
+    def test_load_polaris_file_not_found(self) -> None:
+        """Test error when Polaris data directory does not exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Non-existent directory
+            non_existent = Path(tmpdir) / "nonexistent"
+            with pytest.raises(
+                FileNotFoundError, match="Polaris data directory not found"
+            ):
+                load_polaris(non_existent)
+
+    def test_load_polaris_no_files(self) -> None:
+        """Test error when directory exists but has no data files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            polaris_dir = Path(tmpdir) / "polaris2025"
+            polaris_dir.mkdir()
+
+            with pytest.raises(FileNotFoundError, match="No Excel or CSV files found"):
+                load_polaris(polaris_dir)
+
+    def test_load_polaris_with_excel(self) -> None:
+        """Test loading Polaris from Excel file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            polaris_dir = Path(tmpdir)
+
+            # Create a mock Excel file with Polaris-style data
+            df = pd.DataFrame(
+                {
+                    "Polity": ["TestPol1", "TestPol2"],
+                    "Original_name": ["Test Polity 1", "Test Polity 2"],
+                    "NGA": ["Region 1", "Region 2"],
+                    "Start": [-100, 100],
+                    "End": [100, 300],
+                    "SomeVariable": [1000, 2000],
+                }
+            )
+
+            excel_path = polaris_dir / "Polaris2025.xlsx"
+            df.to_excel(excel_path, index=False)
+
+            dataset = load_polaris(polaris_dir)
+
+            assert len(dataset.polities) == 2
+            assert dataset.metadata["source"] == "Seshat Polaris-2025"
+            assert "repository" in dataset.metadata
+
+    def test_load_polaris_with_csv(self) -> None:
+        """Test loading Polaris from CSV file when no Excel present."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            polaris_dir = Path(tmpdir)
+
+            df = pd.DataFrame(
+                {
+                    "Polity": ["TestPol1"],
+                    "Original_name": ["Test Polity 1"],
+                    "NGA": ["Region 1"],
+                    "Start": [-100],
+                    "End": [100],
+                }
+            )
+
+            csv_path = polaris_dir / "main_data.csv"
+            df.to_csv(csv_path, index=False)
+
+            dataset = load_polaris(polaris_dir)
+
+            assert len(dataset.polities) == 1
+
+    def test_load_polaris_skips_threads_csv(self) -> None:
+        """Test that load_polaris skips polity_threads.csv for main data."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            polaris_dir = Path(tmpdir)
+
+            # Create threads file with different schema
+            threads_df = pd.DataFrame(
+                {
+                    "thread_id": [1, 2],
+                    "polity": ["Pol1", "Pol2"],
+                }
+            )
+            threads_path = polaris_dir / "polity_threads.csv"
+            threads_df.to_csv(threads_path, index=False)
+
+            # Create main data file
+            main_df = pd.DataFrame(
+                {
+                    "Polity": ["TestPol1"],
+                    "Original_name": ["Test Polity 1"],
+                    "NGA": ["Region 1"],
+                    "Start": [-100],
+                    "End": [100],
+                }
+            )
+            main_path = polaris_dir / "main_data.csv"
+            main_df.to_csv(main_path, index=False)
+
+            dataset = load_polaris(polaris_dir)
+
+            # Should load main_data.csv, not polity_threads.csv
+            assert len(dataset.polities) == 1
+            assert dataset.polities[0].id == "TestPol1"
+
+
+class TestLoadPolarisThreads:
+    """Tests for the load_polaris_threads function."""
+
+    def test_load_threads_not_found(self) -> None:
+        """Test error when threads file not found."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pytest.raises(
+                FileNotFoundError, match="Polity threads file not found"
+            ):
+                load_polaris_threads(tmpdir)
+
+    def test_load_threads_success(self) -> None:
+        """Test successful loading of threads file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            polaris_dir = Path(tmpdir)
+
+            threads_df = pd.DataFrame(
+                {
+                    "thread_id": [1, 2, 3],
+                    "polity_name": ["Pol1", "Pol2", "Pol3"],
+                    "predecessor": ["", "Pol1", "Pol2"],
+                }
+            )
+            threads_path = polaris_dir / "polity_threads.csv"
+            threads_df.to_csv(threads_path, index=False)
+
+            result = load_polaris_threads(polaris_dir)
+
+            assert isinstance(result, pd.DataFrame)
+            assert len(result) == 3
+            assert "thread_id" in result.columns
+
+
+class TestSeshatDBDatasetSelection:
+    """Tests for SeshatDB dataset selection."""
+
+    def test_default_dataset_is_polaris(self) -> None:
+        """Test that default dataset is Polaris-2025."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SeshatDB(data_path=tmpdir, dataset=DATASET_POLARIS)
+            assert db._dataset_name == DATASET_POLARIS
+
+    def test_equinox_dataset_selection(self) -> None:
+        """Test selecting Equinox-2020 dataset."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SeshatDB(data_path=tmpdir, dataset=DATASET_EQUINOX)
+            assert db._dataset_name == DATASET_EQUINOX
+
+    def test_invalid_dataset_raises_error(self) -> None:
+        """Test that invalid dataset name raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid dataset"):
+            SeshatDB(dataset="invalid_dataset")
+
+    def test_case_insensitive_dataset_name(self) -> None:
+        """Test that dataset name is case-insensitive."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_upper = SeshatDB(data_path=tmpdir, dataset="POLARIS2025")
+            db_mixed = SeshatDB(data_path=tmpdir, dataset="Polaris2025")
+
+            assert db_upper._dataset_name == DATASET_POLARIS
+            assert db_mixed._dataset_name == DATASET_POLARIS
+
+    def test_dataset_name_property(self) -> None:
+        """Test the dataset_name property."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create mock data
+            df = pd.DataFrame(
+                {
+                    "Polity": ["TestPol"],
+                    "Original_name": ["Test Polity"],
+                    "NGA": ["Region"],
+                    "Start": [0],
+                    "End": [100],
+                }
+            )
+            excel_path = Path(tmpdir) / "test.xlsx"
+            df.to_excel(excel_path, index=False)
+
+            db = SeshatDB(data_path=tmpdir, dataset=DATASET_EQUINOX)
+            # Force loading
+            db._ensure_loaded()
+
+            assert db.dataset_name == DATASET_EQUINOX
+
+
+class TestSeshatDBAutoDetect:
+    """Tests for SeshatDB auto-detecting dataset from path."""
+
+    def test_auto_detect_polaris_from_path(self) -> None:
+        """Test auto-detecting Polaris dataset from path name."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            polaris_dir = Path(tmpdir) / "polaris2025"
+            polaris_dir.mkdir()
+
+            df = pd.DataFrame(
+                {
+                    "Polity": ["TestPol"],
+                    "Original_name": ["Test Polity"],
+                    "NGA": ["Region"],
+                    "Start": [0],
+                    "End": [100],
+                }
+            )
+            excel_path = polaris_dir / "data.xlsx"
+            df.to_excel(excel_path, index=False)
+
+            db = SeshatDB(data_path=polaris_dir)
+            db._ensure_loaded()
+
+            # Should auto-detect as Polaris
+            assert db._dataset_name == DATASET_POLARIS
+
+    def test_auto_detect_equinox_from_path(self) -> None:
+        """Test auto-detecting Equinox dataset from path name."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            seshat_dir = Path(tmpdir) / "seshat"
+            seshat_dir.mkdir()
+
+            df = pd.DataFrame(
+                {
+                    "Polity": ["TestPol"],
+                    "Original_name": ["Test Polity"],
+                    "NGA": ["Region"],
+                    "Start": [0],
+                    "End": [100],
+                }
+            )
+            excel_path = seshat_dir / "data.xlsx"
+            df.to_excel(excel_path, index=False)
+
+            db = SeshatDB(data_path=seshat_dir)
+            db._ensure_loaded()
+
+            # Should auto-detect as Equinox
+            assert db._dataset_name == DATASET_EQUINOX
+
+
+class TestSeshatDBWithBothDatasets:
+    """Tests for SeshatDB with both datasets."""
+
+    def test_load_both_datasets_separately(self) -> None:
+        """Test loading both datasets in separate SeshatDB instances."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create Equinox data
+            equinox_dir = Path(tmpdir) / "equinox"
+            equinox_dir.mkdir()
+            equinox_df = pd.DataFrame(
+                {
+                    "Polity": ["EqPol1", "EqPol2"],
+                    "Original_name": ["Equinox 1", "Equinox 2"],
+                    "NGA": ["RegionA", "RegionB"],
+                    "Start": [0, 100],
+                    "End": [100, 200],
+                }
+            )
+            equinox_df.to_excel(equinox_dir / "equinox.xlsx", index=False)
+
+            # Create Polaris data
+            polaris_dir = Path(tmpdir) / "polaris"
+            polaris_dir.mkdir()
+            polaris_df = pd.DataFrame(
+                {
+                    "Polity": ["PolPol1", "PolPol2", "PolPol3"],
+                    "Original_name": ["Polaris 1", "Polaris 2", "Polaris 3"],
+                    "NGA": ["RegionX", "RegionY", "RegionZ"],
+                    "Start": [0, 100, 200],
+                    "End": [100, 200, 300],
+                }
+            )
+            polaris_df.to_excel(polaris_dir / "polaris.xlsx", index=False)
+
+            # Load both
+            db_equinox = SeshatDB(data_path=equinox_dir, dataset=DATASET_EQUINOX)
+            db_polaris = SeshatDB(data_path=polaris_dir, dataset=DATASET_POLARIS)
+
+            db_equinox._ensure_loaded()
+            db_polaris._ensure_loaded()
+
+            # Should have different data
+            assert len(db_equinox._polity_index) == 2
+            assert len(db_polaris._polity_index) == 3
+
+            assert "EqPol1" in db_equinox._polity_index
+            assert "PolPol1" in db_polaris._polity_index
+
+
+class TestDatasetConstants:
+    """Tests for dataset constants."""
+
+    def test_dataset_equinox_value(self) -> None:
+        """Test DATASET_EQUINOX constant value."""
+        assert DATASET_EQUINOX == "equinox2020"
+
+    def test_dataset_polaris_value(self) -> None:
+        """Test DATASET_POLARIS constant value."""
+        assert DATASET_POLARIS == "polaris2025"
+
+    def test_constants_importable_from_package(self) -> None:
+        """Test that constants are importable from package."""
+        from cliodynamics.data import DATASET_EQUINOX, DATASET_POLARIS
+
+        assert DATASET_EQUINOX == "equinox2020"
+        assert DATASET_POLARIS == "polaris2025"
+
+
+class TestPolarisParsingDifferences:
+    """Tests for Polaris-specific parsing differences."""
+
+    def test_lowercase_column_names(self) -> None:
+        """Test that lowercase column names work (Polaris style)."""
+        df = pd.DataFrame(
+            {
+                "polity": ["TestPol"],
+                "original_name": ["Test Polity"],
+                "nga": ["Region"],
+                "start": [0],
+                "end": [100],
+            }
+        )
+
+        dataset = parse_seshat_dataframe(df)
+
+        assert len(dataset.polities) == 1
+        assert dataset.polities[0].id == "TestPol"
+
+    def test_mixed_case_column_names(self) -> None:
+        """Test that mixed case column names work (Equinox style)."""
+        df = pd.DataFrame(
+            {
+                "Polity": ["TestPol"],
+                "Original_name": ["Test Polity"],
+                "NGA": ["Region"],
+                "Start": [0],
+                "End": [100],
+            }
+        )
+
+        dataset = parse_seshat_dataframe(df)
+
+        assert len(dataset.polities) == 1
+        assert dataset.polities[0].id == "TestPol"
+
+
+class TestModuleImports:
+    """Tests for module imports."""
+
+    def test_import_load_polaris(self) -> None:
+        """Test that load_polaris is importable from package."""
+        from cliodynamics.data import load_polaris
+
+        assert callable(load_polaris)
+
+    def test_import_load_polaris_threads(self) -> None:
+        """Test that load_polaris_threads is importable from package."""
+        from cliodynamics.data import load_polaris_threads
+
+        assert callable(load_polaris_threads)
+
+    def test_import_dataset_constants(self) -> None:
+        """Test that dataset constants are importable."""
+        from cliodynamics.data import DATASET_EQUINOX, DATASET_POLARIS
+
+        assert DATASET_EQUINOX is not None
+        assert DATASET_POLARIS is not None


### PR DESCRIPTION
## Summary

- Add `download_polaris.py` for downloading Polaris-2025 dataset from GitHub
- Add `load_polaris()` and `load_polaris_threads()` parser functions  
- Update `SeshatDB` to support both datasets with explicit selection
- Add comprehensive tests for Polaris-specific functionality

## Changes

### New Files
- `src/cliodynamics/data/download_polaris.py` - Downloads Polaris-2025 Excel and polity_threads.csv
- `tests/data/test_download_polaris.py` - Tests for download functionality (with mocking)
- `tests/data/test_polaris.py` - Tests for Polaris parsing and SeshatDB integration

### Modified Files
- `src/cliodynamics/data/parser.py` - Added `load_polaris()` and `load_polaris_threads()` functions
- `src/cliodynamics/data/access.py` - Updated `SeshatDB` with dataset selection support
- `src/cliodynamics/data/__init__.py` - Export new functions and constants

## Dataset Selection

```python
# Default to Polaris-2025 (primary dataset)
db = SeshatDB()

# Explicit selection
db_polaris = SeshatDB(dataset="polaris2025")
db_equinox = SeshatDB(dataset="equinox2020")

# Check which dataset is loaded
print(db.dataset_name)  # "polaris2025"
```

## Key Differences Documented

| Feature | Polaris-2025 | Equinox-2020 |
|---------|--------------|--------------|
| Source | GitHub (live Seshat API export) | Zenodo (static snapshot) |
| Additional files | polity_threads.csv | - |
| Default | Yes (primary) | No (legacy) |
| Use case | New case studies | Reproducibility |

## Test Plan

- [x] All 70 tests in `tests/data/` pass
- [x] All 51 tests in `tests/test_data.py` pass
- [x] All 49 tests in `tests/test_access.py` pass
- [x] Ruff check passes with no errors
- [x] Ruff format applied

Closes #27

---

Generated with [Claude Code](https://claude.com/claude-code)