### PR TITLE
Add visualization module for time series, phase space, and cycles

### DIFF
--- a/src/cliodynamics/viz/__init__.py
+++ b/src/cliodynamics/viz/__init__.py
@@ -1,10 +1,16 @@
 """
 Visualization module for cliodynamics.
 
-Provides standardized chart and image generation for essays.
+Provides standardized chart, image, and plot generation for essays and analysis.
+
+Submodules:
+    charts: Altair-based charts (timelines, bar charts, heatmaps)
+    images: Gemini-generated illustrations
+    plots: Matplotlib-based scientific plots (time series, phase space)
+    cycles: Secular cycle detection and visualization
 
 Usage:
-    from cliodynamics.viz import charts, images
+    from cliodynamics.viz import charts, images, plots, cycles
 
     # Create a chart
     chart = charts.create_timeline_chart(df, 'nga', 'start', 'end', 'region')
@@ -12,8 +18,16 @@ Usage:
 
     # Generate an image
     images.generate_image("A detailed prompt...", "output.png")
+
+    # Create time series plot
+    fig = plots.plot_time_series(results, variables=['N', 'W', 'psi'])
+    plots.save_figure(fig, 'timeseries.png')
+
+    # Detect and plot secular cycles
+    detected = cycles.detect_secular_cycles(results['psi'])
+    fig = cycles.plot_with_cycles(results, detected)
 """
 
-from cliodynamics.viz import charts, images
+from cliodynamics.viz import charts, cycles, images, plots
 
-__all__ = ['charts', 'images']
+__all__ = ["charts", "images", "plots", "cycles"]

--- a/src/cliodynamics/viz/cycles.py
+++ b/src/cliodynamics/viz/cycles.py
@@ -1,0 +1,659 @@
+"""Secular cycle detection and visualization for cliodynamics analysis.
+
+This module provides tools for detecting and visualizing secular cycles
+(long-term periodic patterns) in SDT model output, following the methodology
+in Turchin & Nefedov (2009) Secular Cycles.
+
+Secular cycles are multi-generational oscillations (typically 100-300 years)
+in societal dynamics driven by demographic-structural pressures. This module
+identifies cycle phases:
+- Expansion: Growth, low instability
+- Stagflation: Stagnation, rising pressures
+- Crisis: Peak instability, potential collapse
+- Depression/Intercycle: Recovery, low population
+
+IMPORTANT: After generating any plot, visually verify it looks correct
+before committing.
+
+Example:
+    >>> from cliodynamics.viz.cycles import detect_secular_cycles, plot_with_cycles
+    >>> cycles = detect_secular_cycles(results['psi'])
+    >>> fig = plot_with_cycles(results, cycles)
+    >>> fig.savefig('cycles.png')
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.figure import Figure
+from matplotlib.patches import Rectangle
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
+    from pandas import DataFrame, Series
+
+    from cliodynamics.simulation import SimulationResult
+
+logger = logging.getLogger(__name__)
+
+
+class CyclePhase(Enum):
+    """Phase of a secular cycle.
+
+    Following Turchin & Nefedov (2009), secular cycles consist of:
+    - EXPANSION: Population growth, economic development, state formation
+    - STAGFLATION: Stagnation, rising inequality, elite overproduction
+    - CRISIS: Instability peaks, potential state collapse
+    - DEPRESSION: Population decline, recovery begins
+    """
+
+    EXPANSION = "expansion"
+    STAGFLATION = "stagflation"
+    CRISIS = "crisis"
+    DEPRESSION = "depression"
+
+
+# Colors for cycle phases
+PHASE_COLORS = {
+    CyclePhase.EXPANSION: "#90EE90",  # Light green
+    CyclePhase.STAGFLATION: "#FFD700",  # Gold
+    CyclePhase.CRISIS: "#FF6B6B",  # Light red
+    CyclePhase.DEPRESSION: "#87CEEB",  # Sky blue
+}
+
+
+@dataclass
+class CyclePoint:
+    """A significant point in a secular cycle (peak or trough).
+
+    Attributes:
+        time: Time at which the point occurs.
+        value: Value of the variable at the point.
+        point_type: Type of point ('peak' or 'trough').
+        index: Index in the original time series.
+    """
+
+    time: float
+    value: float
+    point_type: str  # 'peak' or 'trough'
+    index: int
+
+
+@dataclass
+class SecularCycle:
+    """Represents a detected secular cycle.
+
+    Attributes:
+        start_time: Beginning of the cycle (typically a trough).
+        end_time: End of the cycle (next trough).
+        peak_time: Time of peak instability.
+        peak_value: Maximum instability value in cycle.
+        trough_value: Minimum instability at cycle start.
+        duration: Length of cycle in time units.
+        amplitude: Peak-to-trough difference.
+        phases: List of (start_time, end_time, phase) tuples.
+    """
+
+    start_time: float
+    end_time: float
+    peak_time: float
+    peak_value: float
+    trough_value: float
+    duration: float = field(init=False)
+    amplitude: float = field(init=False)
+    phases: list[tuple[float, float, CyclePhase]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        """Compute derived quantities."""
+        self.duration = self.end_time - self.start_time
+        self.amplitude = self.peak_value - self.trough_value
+
+
+@dataclass
+class CycleDetectionResult:
+    """Results from secular cycle detection.
+
+    Attributes:
+        cycles: List of detected SecularCycle objects.
+        peaks: List of CyclePoint objects for peaks.
+        troughs: List of CyclePoint objects for troughs.
+        mean_period: Average cycle period (time between troughs).
+        mean_amplitude: Average peak-to-trough amplitude.
+    """
+
+    cycles: list[SecularCycle]
+    peaks: list[CyclePoint]
+    troughs: list[CyclePoint]
+    mean_period: float | None = None
+    mean_amplitude: float | None = None
+
+    def __post_init__(self) -> None:
+        """Compute summary statistics."""
+        if self.cycles:
+            self.mean_period = np.mean([c.duration for c in self.cycles])
+            self.mean_amplitude = np.mean([c.amplitude for c in self.cycles])
+
+
+def detect_peaks_and_troughs(
+    values: ArrayLike,
+    times: ArrayLike | None = None,
+    min_prominence: float | None = None,
+    min_distance: int = 1,
+) -> tuple[list[CyclePoint], list[CyclePoint]]:
+    """Detect peaks and troughs in a time series.
+
+    Uses scipy's find_peaks for robust peak detection with prominence filtering.
+
+    Args:
+        values: 1D array of values to analyze.
+        times: Optional time values corresponding to values. If None, uses indices.
+        min_prominence: Minimum prominence for peak detection. If None, uses
+            10% of value range.
+        min_distance: Minimum number of points between peaks.
+
+    Returns:
+        Tuple of (peaks, troughs) where each is a list of CyclePoint objects.
+
+    Example:
+        >>> peaks, troughs = detect_peaks_and_troughs(results['psi'].values)
+    """
+    from scipy.signal import find_peaks
+
+    values = np.asarray(values)
+    if times is None:
+        times = np.arange(len(values))
+    else:
+        times = np.asarray(times)
+
+    # Determine prominence threshold
+    if min_prominence is None:
+        value_range = values.max() - values.min()
+        min_prominence = value_range * 0.1 if value_range > 0 else 0.0
+
+    # Find peaks
+    peak_indices, peak_props = find_peaks(
+        values, prominence=min_prominence, distance=min_distance
+    )
+
+    peaks = [
+        CyclePoint(
+            time=float(times[i]),
+            value=float(values[i]),
+            point_type="peak",
+            index=int(i),
+        )
+        for i in peak_indices
+    ]
+
+    # Find troughs (peaks of negated signal)
+    trough_indices, trough_props = find_peaks(
+        -values, prominence=min_prominence, distance=min_distance
+    )
+
+    troughs = [
+        CyclePoint(
+            time=float(times[i]),
+            value=float(values[i]),
+            point_type="trough",
+            index=int(i),
+        )
+        for i in trough_indices
+    ]
+
+    return peaks, troughs
+
+
+def detect_secular_cycles(
+    values: ArrayLike | Series,
+    times: ArrayLike | None = None,
+    min_prominence: float | None = None,
+    min_cycle_length: float | None = None,
+    phase_thresholds: dict[str, float] | None = None,
+) -> CycleDetectionResult:
+    """Detect secular cycles in a time series.
+
+    Identifies complete cycles from trough to trough, with peak detection
+    and optional phase classification.
+
+    Args:
+        values: Time series values (typically Political Stress Index psi).
+        times: Optional time values. If None, uses integer indices.
+        min_prominence: Minimum prominence for peak/trough detection.
+        min_cycle_length: Minimum duration for a valid cycle.
+        phase_thresholds: Dict with 'expansion_end', 'stagflation_end' fractions
+            (relative to cycle duration) for phase boundaries.
+
+    Returns:
+        CycleDetectionResult with detected cycles and summary statistics.
+
+    Example:
+        >>> cycles = detect_secular_cycles(results['psi'])
+        >>> print(f"Found {len(cycles.cycles)} cycles")
+        >>> print(f"Mean period: {cycles.mean_period:.1f} years")
+    """
+    # Handle pandas Series
+    if hasattr(values, "values"):
+        values = values.values
+    values = np.asarray(values)
+
+    if times is None:
+        times = np.arange(len(values))
+    elif hasattr(times, "values"):
+        times = times.values
+    times = np.asarray(times)
+
+    # Default phase thresholds (relative to cycle duration)
+    if phase_thresholds is None:
+        phase_thresholds = {
+            "expansion_end": 0.3,  # First 30% is expansion
+            "stagflation_end": 0.6,  # 30-60% is stagflation
+            # 60-peak is crisis, peak-end is depression
+        }
+
+    # Detect peaks and troughs
+    peaks, troughs = detect_peaks_and_troughs(values, times, min_prominence)
+
+    # Build cycles from trough to trough
+    cycles: list[SecularCycle] = []
+
+    for i in range(len(troughs) - 1):
+        trough1 = troughs[i]
+        trough2 = troughs[i + 1]
+
+        # Find peak between these troughs
+        cycle_peaks = [p for p in peaks if trough1.time < p.time < trough2.time]
+
+        if not cycle_peaks:
+            continue  # No peak found, skip this cycle
+
+        # Use the highest peak in this interval
+        main_peak = max(cycle_peaks, key=lambda p: p.value)
+
+        # Check minimum cycle length
+        duration = trough2.time - trough1.time
+        if min_cycle_length is not None and duration < min_cycle_length:
+            continue
+
+        # Classify phases
+        phases = _classify_phases(
+            trough1.time, trough2.time, main_peak.time, phase_thresholds
+        )
+
+        cycle = SecularCycle(
+            start_time=trough1.time,
+            end_time=trough2.time,
+            peak_time=main_peak.time,
+            peak_value=main_peak.value,
+            trough_value=trough1.value,
+            phases=phases,
+        )
+        cycles.append(cycle)
+
+    return CycleDetectionResult(cycles=cycles, peaks=peaks, troughs=troughs)
+
+
+def _classify_phases(
+    start: float,
+    end: float,
+    peak: float,
+    thresholds: dict[str, float],
+) -> list[tuple[float, float, CyclePhase]]:
+    """Classify phases within a secular cycle.
+
+    Args:
+        start: Cycle start time (trough).
+        end: Cycle end time (next trough).
+        peak: Peak time.
+        thresholds: Phase boundary thresholds.
+
+    Returns:
+        List of (start, end, phase) tuples.
+    """
+    duration = end - start
+    expansion_end = start + duration * thresholds.get("expansion_end", 0.3)
+    stagflation_end = start + duration * thresholds.get("stagflation_end", 0.6)
+
+    # Ensure phases don't overlap with peak
+    expansion_end = min(expansion_end, peak - 0.01 * duration)
+    stagflation_end = min(stagflation_end, peak - 0.001 * duration)
+    stagflation_end = max(stagflation_end, expansion_end + 0.01 * duration)
+
+    phases = [
+        (start, expansion_end, CyclePhase.EXPANSION),
+        (expansion_end, stagflation_end, CyclePhase.STAGFLATION),
+        (stagflation_end, peak, CyclePhase.CRISIS),
+        (peak, end, CyclePhase.DEPRESSION),
+    ]
+
+    return phases
+
+
+def plot_with_cycles(
+    results: SimulationResult | DataFrame,
+    cycles: CycleDetectionResult,
+    variable: str = "psi",
+    time_column: str = "t",
+    title: str = "Political Stress Index with Secular Cycles",
+    figsize: tuple[float, float] = (12, 6),
+    show_phases: bool = True,
+    show_peaks: bool = True,
+    show_troughs: bool = True,
+    annotate_cycles: bool = True,
+) -> Figure:
+    """Plot time series with secular cycles highlighted.
+
+    Creates a time series plot with cycle phases shown as shaded regions
+    and peaks/troughs marked.
+
+    Args:
+        results: SimulationResult or DataFrame with time series data.
+        cycles: CycleDetectionResult from detect_secular_cycles.
+        variable: Variable to plot (typically 'psi').
+        time_column: Name of time column.
+        title: Plot title.
+        figsize: Figure size (width, height) in inches.
+        show_phases: If True, shade cycle phases with colors.
+        show_peaks: If True, mark peak points.
+        show_troughs: If True, mark trough points.
+        annotate_cycles: If True, add cycle number labels.
+
+    Returns:
+        Matplotlib Figure object.
+
+    Example:
+        >>> cycles = detect_secular_cycles(results['psi'])
+        >>> fig = plot_with_cycles(results, cycles)
+        >>> fig.savefig('cycles.png')
+    """
+    # Get DataFrame from results
+    if hasattr(results, "df"):
+        df = results.df
+    else:
+        df = results
+
+    t = df[time_column].values
+    y = df[variable].values
+
+    fig, ax = plt.subplots(figsize=figsize)
+
+    # Set y limits first
+    y_margin = 0.1 * (y.max() - y.min())
+    ax.set_ylim(y.min() - y_margin, y.max() + y_margin)
+
+    # Draw phase backgrounds with correct limits
+    if show_phases:
+        for cycle in cycles.cycles:
+            for start, end, phase in cycle.phases:
+                rect = Rectangle(
+                    (start, y.min() - y_margin),
+                    end - start,
+                    y.max() - y.min() + 2 * y_margin,
+                    facecolor=PHASE_COLORS[phase],
+                    alpha=0.3,
+                    edgecolor="none",
+                    zorder=1,
+                )
+                ax.add_patch(rect)
+
+    # Plot main line
+    ax.plot(t, y, color="#0072B2", linewidth=1.5, label=variable, zorder=3)
+
+    # Mark peaks
+    if show_peaks and cycles.peaks:
+        peak_times = [p.time for p in cycles.peaks]
+        peak_values = [p.value for p in cycles.peaks]
+        ax.scatter(
+            peak_times,
+            peak_values,
+            color="red",
+            marker="v",
+            s=80,
+            zorder=5,
+            label="Peaks",
+        )
+
+    # Mark troughs
+    if show_troughs and cycles.troughs:
+        trough_times = [p.time for p in cycles.troughs]
+        trough_values = [p.value for p in cycles.troughs]
+        ax.scatter(
+            trough_times,
+            trough_values,
+            color="green",
+            marker="^",
+            s=80,
+            zorder=5,
+            label="Troughs",
+        )
+
+    # Annotate cycles
+    if annotate_cycles:
+        for i, cycle in enumerate(cycles.cycles):
+            mid_time = (cycle.start_time + cycle.end_time) / 2
+            ax.annotate(
+                f"Cycle {i + 1}",
+                xy=(mid_time, y.max() + 0.05 * (y.max() - y.min())),
+                ha="center",
+                fontsize=9,
+                color="gray",
+            )
+
+    ax.set_xlabel("Time")
+    ax.set_ylabel(_get_variable_label(variable))
+    ax.set_title(title, fontsize=14)
+    ax.set_xlim(t[0], t[-1])
+
+    # Create legend with phase colors
+    if show_phases:
+        from matplotlib.patches import Patch
+
+        legend_elements = [
+            Patch(
+                facecolor=PHASE_COLORS[CyclePhase.EXPANSION],
+                alpha=0.3,
+                label="Expansion",
+            ),
+            Patch(
+                facecolor=PHASE_COLORS[CyclePhase.STAGFLATION],
+                alpha=0.3,
+                label="Stagflation",
+            ),
+            Patch(facecolor=PHASE_COLORS[CyclePhase.CRISIS], alpha=0.3, label="Crisis"),
+            Patch(
+                facecolor=PHASE_COLORS[CyclePhase.DEPRESSION],
+                alpha=0.3,
+                label="Depression",
+            ),
+        ]
+        if show_peaks:
+            legend_elements.append(
+                plt.Line2D(
+                    [0],
+                    [0],
+                    marker="v",
+                    color="w",
+                    markerfacecolor="red",
+                    markersize=10,
+                    label="Peak",
+                )
+            )
+        if show_troughs:
+            legend_elements.append(
+                plt.Line2D(
+                    [0],
+                    [0],
+                    marker="^",
+                    color="w",
+                    markerfacecolor="green",
+                    markersize=10,
+                    label="Trough",
+                )
+            )
+        ax.legend(handles=legend_elements, loc="upper right", fontsize=9)
+    else:
+        ax.legend(loc="upper right")
+
+    ax.grid(True, alpha=0.3, linestyle="--", zorder=0)
+    fig.tight_layout()
+
+    return fig
+
+
+def plot_cycle_comparison(
+    cycles: CycleDetectionResult,
+    figsize: tuple[float, float] = (10, 8),
+    title: str = "Secular Cycle Comparison",
+) -> Figure:
+    """Create comparison plot of multiple secular cycles.
+
+    Aligns cycles by phase to compare patterns across cycles.
+
+    Args:
+        cycles: CycleDetectionResult with detected cycles.
+        figsize: Figure size (width, height) in inches.
+        title: Plot title.
+
+    Returns:
+        Matplotlib Figure object.
+    """
+    if not cycles.cycles:
+        fig, ax = plt.subplots(figsize=figsize)
+        ax.text(0.5, 0.5, "No cycles detected", ha="center", va="center", fontsize=12)
+        ax.set_title(title)
+        return fig
+
+    fig, axes = plt.subplots(2, 2, figsize=figsize)
+
+    # 1. Duration histogram
+    ax = axes[0, 0]
+    durations = [c.duration for c in cycles.cycles]
+    ax.hist(
+        durations, bins=max(5, len(durations) // 2), color="#0072B2", edgecolor="white"
+    )
+    ax.axvline(
+        np.mean(durations),
+        color="red",
+        linestyle="--",
+        label=f"Mean: {np.mean(durations):.1f}",
+    )
+    ax.set_xlabel("Cycle Duration")
+    ax.set_ylabel("Count")
+    ax.set_title("Cycle Duration Distribution")
+    ax.legend()
+
+    # 2. Amplitude histogram
+    ax = axes[0, 1]
+    amplitudes = [c.amplitude for c in cycles.cycles]
+    ax.hist(
+        amplitudes,
+        bins=max(5, len(amplitudes) // 2),
+        color="#D55E00",
+        edgecolor="white",
+    )
+    ax.axvline(
+        np.mean(amplitudes),
+        color="red",
+        linestyle="--",
+        label=f"Mean: {np.mean(amplitudes):.2f}",
+    )
+    ax.set_xlabel("Peak Amplitude")
+    ax.set_ylabel("Count")
+    ax.set_title("Cycle Amplitude Distribution")
+    ax.legend()
+
+    # 3. Duration vs amplitude scatter
+    ax = axes[1, 0]
+    ax.scatter(durations, amplitudes, color="#009E73", s=60)
+    ax.set_xlabel("Duration")
+    ax.set_ylabel("Amplitude")
+    ax.set_title("Duration vs Amplitude")
+    # Add correlation
+    if len(durations) > 2:
+        corr = np.corrcoef(durations, amplitudes)[0, 1]
+        ax.annotate(
+            f"r = {corr:.2f}", xy=(0.05, 0.95), xycoords="axes fraction", fontsize=10
+        )
+
+    # 4. Cycle timeline
+    ax = axes[1, 1]
+    for i, cycle in enumerate(cycles.cycles):
+        y = len(cycles.cycles) - i
+        ax.barh(y, cycle.duration, left=cycle.start_time, color="#0072B2", alpha=0.7)
+        ax.scatter([cycle.peak_time], [y], color="red", marker="v", s=50, zorder=5)
+    ax.set_xlabel("Time")
+    ax.set_ylabel("Cycle Number")
+    ax.set_title("Cycle Timeline")
+    ax.set_yticks(range(1, len(cycles.cycles) + 1))
+    ax.set_yticklabels([f"Cycle {i}" for i in range(len(cycles.cycles), 0, -1)])
+
+    fig.suptitle(title, fontsize=14, y=1.02)
+    fig.tight_layout()
+
+    return fig
+
+
+def _get_variable_label(variable: str) -> str:
+    """Get display label for a variable."""
+    labels = {
+        "N": "Population (N)",
+        "E": "Elite Population (E)",
+        "W": "Real Wages (W)",
+        "S": "State Fiscal Health (S)",
+        "psi": "Political Stress Index (\u03c8)",
+        "t": "Time",
+    }
+    return labels.get(variable, variable)
+
+
+def compute_cycle_statistics(cycles: CycleDetectionResult) -> dict:
+    """Compute summary statistics for detected cycles.
+
+    Args:
+        cycles: CycleDetectionResult from detect_secular_cycles.
+
+    Returns:
+        Dictionary with cycle statistics.
+    """
+    if not cycles.cycles:
+        return {
+            "n_cycles": 0,
+            "mean_period": None,
+            "std_period": None,
+            "mean_amplitude": None,
+            "std_amplitude": None,
+        }
+
+    durations = [c.duration for c in cycles.cycles]
+    amplitudes = [c.amplitude for c in cycles.cycles]
+
+    return {
+        "n_cycles": len(cycles.cycles),
+        "mean_period": float(np.mean(durations)),
+        "std_period": float(np.std(durations)) if len(durations) > 1 else 0.0,
+        "min_period": float(np.min(durations)),
+        "max_period": float(np.max(durations)),
+        "mean_amplitude": float(np.mean(amplitudes)),
+        "std_amplitude": float(np.std(amplitudes)) if len(amplitudes) > 1 else 0.0,
+        "min_amplitude": float(np.min(amplitudes)),
+        "max_amplitude": float(np.max(amplitudes)),
+    }
+
+
+__all__ = [
+    "CyclePhase",
+    "CyclePoint",
+    "SecularCycle",
+    "CycleDetectionResult",
+    "detect_secular_cycles",
+    "detect_peaks_and_troughs",
+    "plot_with_cycles",
+    "plot_cycle_comparison",
+    "compute_cycle_statistics",
+    "PHASE_COLORS",
+]

--- a/src/cliodynamics/viz/plots.py
+++ b/src/cliodynamics/viz/plots.py
@@ -1,0 +1,687 @@
+"""Time series and phase space visualization for cliodynamics analysis.
+
+This module provides publication-quality visualizations for SDT model output,
+including time series plots, phase space diagrams (2D and 3D), and
+model vs. observed data comparison plots.
+
+IMPORTANT: After generating any plot, visually verify it looks correct
+before committing. Check that labels are readable, axes are properly scaled,
+and the plot accurately represents the data.
+
+Example:
+    >>> from cliodynamics.viz.plots import plot_time_series, plot_phase_space
+    >>> from cliodynamics.simulation import SimulationResult
+    >>>
+    >>> # Plot time series of multiple variables
+    >>> fig = plot_time_series(
+    ...     results,
+    ...     variables=['N', 'W', 'psi'],
+    ...     labels=['Population', 'Real Wages', 'Instability'],
+    ...     title="Roman Empire 500 BCE - 500 CE"
+    ... )
+    >>> fig.savefig('timeseries.png', dpi=150)
+    >>>
+    >>> # Plot phase space diagram
+    >>> fig = plot_phase_space(results, x='W', y='psi', color_by='t')
+    >>> fig.savefig('phase_space.png', dpi=150)
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.figure import Figure
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 - required for 3D projection
+
+if TYPE_CHECKING:
+    from pandas import DataFrame
+
+    from cliodynamics.simulation import SimulationResult
+
+logger = logging.getLogger(__name__)
+
+# Standard style settings for publication quality
+STYLE_CONFIG = {
+    "figure.figsize": (10, 6),
+    "figure.dpi": 150,
+    "axes.titlesize": 14,
+    "axes.labelsize": 12,
+    "axes.linewidth": 1.0,
+    "lines.linewidth": 1.5,
+    "legend.fontsize": 10,
+    "legend.framealpha": 0.9,
+    "xtick.labelsize": 10,
+    "ytick.labelsize": 10,
+    "grid.alpha": 0.3,
+    "grid.linestyle": "--",
+}
+
+# Default color palette (colorblind-friendly)
+DEFAULT_COLORS = [
+    "#0072B2",  # Blue
+    "#D55E00",  # Vermillion
+    "#009E73",  # Green
+    "#CC79A7",  # Pink
+    "#F0E442",  # Yellow
+    "#56B4E9",  # Light blue
+    "#E69F00",  # Orange
+]
+
+# Variable display names
+VARIABLE_LABELS = {
+    "N": "Population (N)",
+    "E": "Elite Population (E)",
+    "W": "Real Wages (W)",
+    "S": "State Fiscal Health (S)",
+    "psi": "Political Stress Index (\u03c8)",
+    "t": "Time",
+}
+
+
+def _apply_style(fig: Figure) -> None:
+    """Apply consistent styling to a figure."""
+    with plt.rc_context(STYLE_CONFIG):
+        fig.tight_layout()
+
+
+def _get_label(variable: str, custom_labels: dict[str, str] | None = None) -> str:
+    """Get display label for a variable.
+
+    Args:
+        variable: Variable name.
+        custom_labels: Optional custom label mapping.
+
+    Returns:
+        Display label for the variable.
+    """
+    if custom_labels and variable in custom_labels:
+        return custom_labels[variable]
+    return VARIABLE_LABELS.get(variable, variable)
+
+
+def plot_time_series(
+    results: SimulationResult | DataFrame,
+    variables: list[str] | None = None,
+    labels: list[str] | None = None,
+    title: str = "SDT Model Time Series",
+    time_column: str = "t",
+    figsize: tuple[float, float] = (10, 6),
+    colors: list[str] | None = None,
+    subplot_layout: bool = False,
+    share_x: bool = True,
+    grid: bool = True,
+) -> Figure:
+    """Create time series plot of simulation results.
+
+    Plots one or more variables over time, either on a single axis
+    or as vertically stacked subplots.
+
+    Args:
+        results: SimulationResult object or DataFrame with time series data.
+        variables: List of variable names to plot. Defaults to all SDT variables.
+        labels: Display labels for variables (same order as variables).
+        title: Plot title.
+        time_column: Name of time column in data.
+        figsize: Figure size (width, height) in inches.
+        colors: Custom color list for variables.
+        subplot_layout: If True, use separate subplots for each variable.
+        share_x: If True and subplot_layout is True, share x-axis across subplots.
+        grid: If True, show grid lines.
+
+    Returns:
+        Matplotlib Figure object.
+
+    Example:
+        >>> fig = plot_time_series(
+        ...     results,
+        ...     variables=['N', 'W', 'psi'],
+        ...     labels=['Population', 'Real Wages', 'Instability'],
+        ...     title="Roman Empire Dynamics"
+        ... )
+        >>> fig.savefig('timeseries.png')
+    """
+    # Get DataFrame from results
+    if hasattr(results, "df"):
+        df = results.df
+    else:
+        df = results
+
+    # Default variables
+    if variables is None:
+        variables = ["N", "E", "W", "S", "psi"]
+        variables = [v for v in variables if v in df.columns]
+
+    # Validate variables exist
+    for var in variables:
+        if var not in df.columns:
+            raise ValueError(
+                f"Variable '{var}' not found in data columns: {df.columns.tolist()}"
+            )
+
+    # Default labels
+    if labels is None:
+        labels = [_get_label(v) for v in variables]
+    elif len(labels) != len(variables):
+        raise ValueError(
+            f"Length of labels ({len(labels)}) must match variables ({len(variables)})"
+        )
+
+    # Colors
+    if colors is None:
+        colors = DEFAULT_COLORS[: len(variables)]
+    elif len(colors) < len(variables):
+        colors = colors + DEFAULT_COLORS[len(colors) : len(variables)]
+
+    # Get time values
+    t = df[time_column].values
+
+    with plt.rc_context(STYLE_CONFIG):
+        if subplot_layout:
+            # Create stacked subplots
+            fig, axes = plt.subplots(
+                len(variables),
+                1,
+                figsize=(figsize[0], figsize[1] * len(variables) / 2),
+                sharex=share_x,
+            )
+            if len(variables) == 1:
+                axes = [axes]
+
+            for i, (var, label, color) in enumerate(zip(variables, labels, colors)):
+                ax = axes[i]
+                ax.plot(t, df[var].values, color=color, linewidth=1.5)
+                ax.set_ylabel(label)
+                if grid:
+                    ax.grid(True, alpha=0.3, linestyle="--")
+                ax.set_xlim(t[0], t[-1])
+
+            axes[-1].set_xlabel(_get_label(time_column))
+            axes[0].set_title(title, fontsize=14)
+        else:
+            # Single plot with all variables
+            fig, ax = plt.subplots(figsize=figsize)
+
+            for var, label, color in zip(variables, labels, colors):
+                ax.plot(t, df[var].values, color=color, label=label, linewidth=1.5)
+
+            ax.set_xlabel(_get_label(time_column))
+            ax.set_ylabel("Value")
+            ax.set_title(title, fontsize=14)
+            ax.legend(loc="best")
+            ax.set_xlim(t[0], t[-1])
+            if grid:
+                ax.grid(True, alpha=0.3, linestyle="--")
+
+        fig.tight_layout()
+
+    return fig
+
+
+def plot_phase_space(
+    results: SimulationResult | DataFrame,
+    x: str,
+    y: str,
+    color_by: str | None = "t",
+    title: str | None = None,
+    figsize: tuple[float, float] = (8, 6),
+    colormap: str = "viridis",
+    show_start: bool = True,
+    show_end: bool = True,
+    arrow_interval: int | None = None,
+) -> Figure:
+    """Create 2D phase space diagram.
+
+    Plots trajectory of two variables against each other to show
+    dynamical behavior and attractors.
+
+    Args:
+        results: SimulationResult object or DataFrame with time series data.
+        x: Variable name for x-axis.
+        y: Variable name for y-axis.
+        color_by: Variable to color trajectory by (e.g., 't' for time).
+            If None, uses solid color.
+        title: Plot title. Defaults to auto-generated title.
+        figsize: Figure size (width, height) in inches.
+        colormap: Matplotlib colormap name for trajectory color.
+        show_start: If True, mark starting point with circle.
+        show_end: If True, mark ending point with square.
+        arrow_interval: If set, add direction arrows every N points.
+
+    Returns:
+        Matplotlib Figure object.
+
+    Example:
+        >>> fig = plot_phase_space(results, x='W', y='psi', color_by='t')
+        >>> fig.savefig('phase_space.png')
+    """
+    # Get DataFrame from results
+    if hasattr(results, "df"):
+        df = results.df
+    else:
+        df = results
+
+    # Validate variables
+    for var in [x, y]:
+        if var not in df.columns:
+            raise ValueError(
+                f"Variable '{var}' not in data columns: {df.columns.tolist()}"
+            )
+
+    if color_by is not None and color_by not in df.columns:
+        raise ValueError(
+            f"Color variable '{color_by}' not in columns: {df.columns.tolist()}"
+        )
+
+    x_vals = df[x].values
+    y_vals = df[y].values
+
+    with plt.rc_context(STYLE_CONFIG):
+        fig, ax = plt.subplots(figsize=figsize)
+
+        if color_by is not None:
+            # Color-coded trajectory
+            c_vals = df[color_by].values
+            points = np.array([x_vals, y_vals]).T.reshape(-1, 1, 2)
+            segments = np.concatenate([points[:-1], points[1:]], axis=1)
+
+            from matplotlib.collections import LineCollection
+
+            norm = plt.Normalize(c_vals.min(), c_vals.max())
+            lc = LineCollection(segments, cmap=colormap, norm=norm)
+            lc.set_array(c_vals[:-1])
+            lc.set_linewidth(1.5)
+            line = ax.add_collection(lc)
+
+            fig.colorbar(line, ax=ax, label=_get_label(color_by))
+        else:
+            # Solid color trajectory
+            ax.plot(x_vals, y_vals, color=DEFAULT_COLORS[0], linewidth=1.5)
+
+        # Mark start and end points
+        if show_start:
+            ax.scatter(
+                [x_vals[0]],
+                [y_vals[0]],
+                color="green",
+                s=100,
+                marker="o",
+                zorder=5,
+                label="Start",
+            )
+        if show_end:
+            ax.scatter(
+                [x_vals[-1]],
+                [y_vals[-1]],
+                color="red",
+                s=100,
+                marker="s",
+                zorder=5,
+                label="End",
+            )
+
+        # Add direction arrows
+        if arrow_interval is not None and arrow_interval > 0:
+            for i in range(arrow_interval, len(x_vals) - 1, arrow_interval):
+                dx = x_vals[i + 1] - x_vals[i]
+                dy = y_vals[i + 1] - y_vals[i]
+                ax.annotate(
+                    "",
+                    xy=(x_vals[i] + dx * 0.5, y_vals[i] + dy * 0.5),
+                    xytext=(x_vals[i], y_vals[i]),
+                    arrowprops=dict(arrowstyle="->", color="gray", lw=1),
+                )
+
+        ax.set_xlabel(_get_label(x))
+        ax.set_ylabel(_get_label(y))
+
+        if title is None:
+            title = f"Phase Space: {_get_label(x)} vs {_get_label(y)}"
+        ax.set_title(title, fontsize=14)
+
+        if show_start or show_end:
+            ax.legend(loc="best")
+
+        ax.autoscale()
+        ax.set_aspect("auto")
+        fig.tight_layout()
+
+    return fig
+
+
+def plot_phase_space_3d(
+    results: SimulationResult | DataFrame,
+    x: str,
+    y: str,
+    z: str,
+    color_by: str | None = "t",
+    title: str | None = None,
+    figsize: tuple[float, float] = (10, 8),
+    colormap: str = "viridis",
+    elevation: float = 20,
+    azimuth: float = 45,
+    show_start: bool = True,
+    show_end: bool = True,
+) -> Figure:
+    """Create 3D phase space diagram.
+
+    Plots trajectory of three variables to visualize higher-dimensional
+    dynamical behavior.
+
+    Args:
+        results: SimulationResult object or DataFrame with time series data.
+        x: Variable name for x-axis.
+        y: Variable name for y-axis.
+        z: Variable name for z-axis.
+        color_by: Variable to color trajectory by. If None, uses solid color.
+        title: Plot title. Defaults to auto-generated title.
+        figsize: Figure size (width, height) in inches.
+        colormap: Matplotlib colormap name for trajectory color.
+        elevation: Viewing elevation angle in degrees.
+        azimuth: Viewing azimuth angle in degrees.
+        show_start: If True, mark starting point.
+        show_end: If True, mark ending point.
+
+    Returns:
+        Matplotlib Figure object.
+
+    Example:
+        >>> fig = plot_phase_space_3d(results, x='N', y='W', z='psi')
+        >>> fig.savefig('phase_space_3d.png')
+    """
+    # Get DataFrame from results
+    if hasattr(results, "df"):
+        df = results.df
+    else:
+        df = results
+
+    # Validate variables
+    for var in [x, y, z]:
+        if var not in df.columns:
+            raise ValueError(
+                f"Variable '{var}' not in data columns: {df.columns.tolist()}"
+            )
+
+    if color_by is not None and color_by not in df.columns:
+        raise ValueError(
+            f"Color variable '{color_by}' not in columns: {df.columns.tolist()}"
+        )
+
+    x_vals = df[x].values
+    y_vals = df[y].values
+    z_vals = df[z].values
+
+    with plt.rc_context(STYLE_CONFIG):
+        fig = plt.figure(figsize=figsize)
+        ax = fig.add_subplot(111, projection="3d")
+
+        if color_by is not None:
+            # Color-coded trajectory using scatter for 3D
+            c_vals = df[color_by].values
+            # Plot line segments with color gradient
+            cmap = plt.colormaps.get_cmap(colormap)
+            for i in range(len(x_vals) - 1):
+                ax.plot(
+                    x_vals[i : i + 2],
+                    y_vals[i : i + 2],
+                    z_vals[i : i + 2],
+                    color=cmap(c_vals[i] / c_vals.max()),
+                    linewidth=1.5,
+                )
+
+            # Add colorbar
+            from matplotlib.cm import ScalarMappable
+
+            mappable = ScalarMappable(
+                norm=plt.Normalize(c_vals.min(), c_vals.max()),
+                cmap=colormap,
+            )
+            mappable.set_array([])
+            fig.colorbar(mappable, ax=ax, shrink=0.6, label=_get_label(color_by))
+        else:
+            # Solid color trajectory
+            ax.plot(x_vals, y_vals, z_vals, color=DEFAULT_COLORS[0], linewidth=1.5)
+
+        # Mark start and end points
+        if show_start:
+            ax.scatter(
+                [x_vals[0]],
+                [y_vals[0]],
+                [z_vals[0]],
+                color="green",
+                s=100,
+                marker="o",
+                label="Start",
+            )
+        if show_end:
+            ax.scatter(
+                [x_vals[-1]],
+                [y_vals[-1]],
+                [z_vals[-1]],
+                color="red",
+                s=100,
+                marker="s",
+                label="End",
+            )
+
+        ax.set_xlabel(_get_label(x))
+        ax.set_ylabel(_get_label(y))
+        ax.set_zlabel(_get_label(z))
+
+        if title is None:
+            title = f"3D Phase Space: {x}, {y}, {z}"
+        ax.set_title(title, fontsize=14)
+
+        ax.view_init(elev=elevation, azim=azimuth)
+
+        if show_start or show_end:
+            ax.legend(loc="best")
+
+        fig.tight_layout()
+
+    return fig
+
+
+def plot_comparison(
+    model_results: SimulationResult | DataFrame,
+    observed_data: DataFrame,
+    variables: list[str],
+    time_column: str = "t",
+    labels: list[str] | None = None,
+    title: str = "Model vs Observed Data",
+    figsize: tuple[float, float] = (10, 6),
+    confidence_bands: bool = False,
+    confidence_columns: dict[str, tuple[str, str]] | None = None,
+    observed_marker: str = "o",
+    model_style: str = "-",
+) -> Figure:
+    """Create comparison plot of model results and observed data.
+
+    Plots model predictions alongside historical observations to assess
+    model fit and calibration quality.
+
+    Args:
+        model_results: SimulationResult or DataFrame with model output.
+        observed_data: DataFrame with observed/historical data.
+        variables: List of variable names to compare.
+        time_column: Name of time column in both datasets.
+        labels: Display labels for variables.
+        title: Plot title.
+        figsize: Figure size (width, height) in inches.
+        confidence_bands: If True, show confidence bands around model.
+        confidence_columns: Dict mapping variable to (lower, upper) column names
+            for confidence bands. Required if confidence_bands is True.
+        observed_marker: Marker style for observed data points.
+        model_style: Line style for model output.
+
+    Returns:
+        Matplotlib Figure object.
+
+    Example:
+        >>> fig = plot_comparison(
+        ...     model_results=simulation,
+        ...     observed_data=historical,
+        ...     variables=['N', 'psi'],
+        ...     confidence_bands=True
+        ... )
+        >>> fig.savefig('comparison.png')
+    """
+    # Get DataFrame from results
+    if hasattr(model_results, "df"):
+        model_df = model_results.df
+    else:
+        model_df = model_results
+
+    # Default labels
+    if labels is None:
+        labels = [_get_label(v) for v in variables]
+
+    # Validate confidence columns if needed
+    if confidence_bands and confidence_columns is None:
+        raise ValueError("confidence_columns required when confidence_bands is True")
+
+    with plt.rc_context(STYLE_CONFIG):
+        fig, axes = plt.subplots(
+            len(variables),
+            1,
+            figsize=(figsize[0], figsize[1] * len(variables) / 2),
+            sharex=True,
+        )
+        if len(variables) == 1:
+            axes = [axes]
+
+        for i, (var, label) in enumerate(zip(variables, labels)):
+            ax = axes[i]
+            color = DEFAULT_COLORS[i % len(DEFAULT_COLORS)]
+
+            # Validate variable exists
+            if var not in model_df.columns:
+                raise ValueError(f"Variable '{var}' not found in model data")
+
+            # Plot model output
+            model_t = model_df[time_column].values
+            model_y = model_df[var].values
+            ax.plot(
+                model_t,
+                model_y,
+                model_style,
+                color=color,
+                label="Model",
+                linewidth=1.5,
+            )
+
+            # Plot confidence bands if requested
+            if confidence_bands and var in confidence_columns:
+                lower_col, upper_col = confidence_columns[var]
+                lower = model_df[lower_col].values
+                upper = model_df[upper_col].values
+                ax.fill_between(
+                    model_t, lower, upper, color=color, alpha=0.2, label="95% CI"
+                )
+
+            # Plot observed data if variable exists
+            if var in observed_data.columns:
+                obs_t = observed_data[time_column].values
+                obs_y = observed_data[var].values
+                # Filter out NaN values
+                mask = ~np.isnan(obs_y)
+                ax.scatter(
+                    obs_t[mask],
+                    obs_y[mask],
+                    marker=observed_marker,
+                    color=color,
+                    facecolors="none",
+                    s=50,
+                    label="Observed",
+                    linewidths=1.5,
+                )
+
+            ax.set_ylabel(label)
+            ax.legend(loc="best")
+            ax.grid(True, alpha=0.3, linestyle="--")
+
+        axes[-1].set_xlabel(_get_label(time_column))
+        axes[0].set_title(title, fontsize=14)
+        fig.tight_layout()
+
+    return fig
+
+
+def save_figure(
+    fig: Figure,
+    path: str | Path,
+    dpi: int = 150,
+    formats: list[str] | None = None,
+) -> list[Path]:
+    """Save figure to file(s) in specified format(s).
+
+    Args:
+        fig: Matplotlib Figure object to save.
+        path: Output file path. Extension determines format if formats not specified.
+        dpi: Resolution for raster formats (PNG).
+        formats: List of formats to save. If None, uses path extension.
+            Supported: 'png', 'svg', 'pdf'.
+
+    Returns:
+        List of saved file paths.
+
+    Example:
+        >>> save_figure(fig, 'output.png')
+        [PosixPath('output.png')]
+        >>> save_figure(fig, 'output', formats=['png', 'svg', 'pdf'])
+        [PosixPath('output.png'), PosixPath('output.svg'), PosixPath('output.pdf')]
+    """
+    path = Path(path)
+
+    if formats is None:
+        formats = [path.suffix.lstrip(".") if path.suffix else "png"]
+
+    saved_paths = []
+    for fmt in formats:
+        fmt = fmt.lower().lstrip(".")
+        if fmt not in ("png", "svg", "pdf"):
+            raise ValueError(f"Unsupported format: {fmt}. Use png, svg, or pdf.")
+
+        output_path = path.with_suffix(f".{fmt}")
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if fmt == "png":
+            fig.savefig(output_path, dpi=dpi, bbox_inches="tight")
+        else:
+            fig.savefig(output_path, bbox_inches="tight")
+
+        logger.info(f"Figure saved to {output_path}")
+        saved_paths.append(output_path)
+
+    # Verification reminder
+    print(VERIFICATION_REMINDER)
+    return saved_paths
+
+
+# Verification reminder
+VERIFICATION_REMINDER = """
+=====================================================================
+  IMPORTANT: Visually verify all plots before committing!
+
+  Check that:
+  1. All text is readable (not too small)
+  2. Axes labels are correct and not cut off
+  3. Legend is visible and correctly positioned
+  4. Data is plotted correctly without artifacts
+  5. Colors are distinguishable
+=====================================================================
+"""
+
+
+__all__ = [
+    "plot_time_series",
+    "plot_phase_space",
+    "plot_phase_space_3d",
+    "plot_comparison",
+    "save_figure",
+    "VARIABLE_LABELS",
+    "DEFAULT_COLORS",
+]

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,0 +1,530 @@
+"""Tests for the visualization module.
+
+Tests cover:
+- Time series plotting
+- Phase space diagrams (2D and 3D)
+- Model vs data comparison plots
+- Secular cycle detection
+- Cycle visualization
+- Export functionality
+"""
+
+import tempfile
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")  # Non-interactive backend for testing
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+
+from cliodynamics.viz import cycles, plots
+
+
+def sample_simulation_df() -> pd.DataFrame:
+    """Create sample simulation data for testing."""
+    t = np.linspace(0, 200, 201)
+    # Create oscillating dynamics
+    N = 0.5 + 0.2 * np.sin(2 * np.pi * t / 100) + 0.1 * np.sin(2 * np.pi * t / 30)
+    E = 0.1 + 0.05 * np.sin(2 * np.pi * t / 100 + np.pi / 4)
+    W = 1.0 - 0.3 * np.sin(2 * np.pi * t / 100)
+    S = 1.0 - 0.2 * np.sin(2 * np.pi * t / 100 + np.pi / 2)
+    psi = 0.5 + 0.4 * np.sin(2 * np.pi * t / 100 + np.pi)
+
+    return pd.DataFrame({"t": t, "N": N, "E": E, "W": W, "S": S, "psi": psi})
+
+
+def sample_observed_df() -> pd.DataFrame:
+    """Create sample observed data for comparison testing."""
+    t = np.array([0, 25, 50, 75, 100, 125, 150, 175, 200])
+    N = 0.5 + 0.2 * np.sin(2 * np.pi * t / 100) + np.random.normal(0, 0.05, len(t))
+    psi = (
+        0.5
+        + 0.4 * np.sin(2 * np.pi * t / 100 + np.pi)
+        + np.random.normal(0, 0.05, len(t))
+    )
+
+    return pd.DataFrame({"t": t, "N": N, "psi": psi})
+
+
+class TestPlotTimeSeries:
+    """Tests for plot_time_series function."""
+
+    def test_basic_time_series(self) -> None:
+        """Test basic time series plot creation."""
+        df = sample_simulation_df()
+        fig = plots.plot_time_series(df, variables=["N", "W"], title="Test Plot")
+
+        assert isinstance(fig, plt.Figure)
+        assert len(fig.axes) == 1
+        plt.close(fig)
+
+    def test_time_series_default_variables(self) -> None:
+        """Test time series with default variables."""
+        df = sample_simulation_df()
+        fig = plots.plot_time_series(df)
+
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_time_series_subplot_layout(self) -> None:
+        """Test time series with subplot layout."""
+        df = sample_simulation_df()
+        fig = plots.plot_time_series(
+            df, variables=["N", "W", "psi"], subplot_layout=True
+        )
+
+        assert isinstance(fig, plt.Figure)
+        assert len(fig.axes) == 3
+        plt.close(fig)
+
+    def test_time_series_custom_labels(self) -> None:
+        """Test time series with custom labels."""
+        df = sample_simulation_df()
+        fig = plots.plot_time_series(
+            df,
+            variables=["N", "W"],
+            labels=["Population", "Wages"],
+            title="Custom Labels",
+        )
+
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_time_series_custom_colors(self) -> None:
+        """Test time series with custom colors."""
+        df = sample_simulation_df()
+        fig = plots.plot_time_series(
+            df,
+            variables=["N", "W"],
+            colors=["red", "blue"],
+        )
+
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_time_series_missing_variable_raises(self) -> None:
+        """Test that missing variable raises ValueError."""
+        df = sample_simulation_df()
+
+        with pytest.raises(ValueError, match="not found"):
+            plots.plot_time_series(df, variables=["nonexistent"])
+
+    def test_time_series_labels_length_mismatch_raises(self) -> None:
+        """Test that mismatched labels length raises ValueError."""
+        df = sample_simulation_df()
+
+        with pytest.raises(ValueError, match="Length of labels"):
+            plots.plot_time_series(df, variables=["N", "W"], labels=["Only One"])
+
+
+class TestPlotPhaseSpace:
+    """Tests for phase space diagram functions."""
+
+    def test_basic_phase_space_2d(self) -> None:
+        """Test basic 2D phase space plot."""
+        df = sample_simulation_df()
+        fig = plots.plot_phase_space(df, x="W", y="psi")
+
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_phase_space_2d_no_color(self) -> None:
+        """Test 2D phase space without color coding."""
+        df = sample_simulation_df()
+        fig = plots.plot_phase_space(df, x="W", y="psi", color_by=None)
+
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_phase_space_2d_with_arrows(self) -> None:
+        """Test 2D phase space with direction arrows."""
+        df = sample_simulation_df()
+        fig = plots.plot_phase_space(df, x="W", y="psi", arrow_interval=20)
+
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_phase_space_2d_custom_colormap(self) -> None:
+        """Test 2D phase space with custom colormap."""
+        df = sample_simulation_df()
+        fig = plots.plot_phase_space(df, x="W", y="psi", colormap="plasma")
+
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_phase_space_2d_missing_variable_raises(self) -> None:
+        """Test that missing variable raises ValueError."""
+        df = sample_simulation_df()
+
+        with pytest.raises(ValueError, match="not in"):
+            plots.plot_phase_space(df, x="nonexistent", y="psi")
+
+    def test_basic_phase_space_3d(self) -> None:
+        """Test basic 3D phase space plot."""
+        df = sample_simulation_df()
+        fig = plots.plot_phase_space_3d(df, x="N", y="W", z="psi")
+
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_phase_space_3d_no_color(self) -> None:
+        """Test 3D phase space without color coding."""
+        df = sample_simulation_df()
+        fig = plots.plot_phase_space_3d(df, x="N", y="W", z="psi", color_by=None)
+
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_phase_space_3d_custom_view(self) -> None:
+        """Test 3D phase space with custom viewing angle."""
+        df = sample_simulation_df()
+        fig = plots.plot_phase_space_3d(
+            df, x="N", y="W", z="psi", elevation=45, azimuth=135
+        )
+
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+
+class TestPlotComparison:
+    """Tests for model vs data comparison plots."""
+
+    def test_basic_comparison(self) -> None:
+        """Test basic comparison plot."""
+        model_df = sample_simulation_df()
+        observed_df = sample_observed_df()
+
+        fig = plots.plot_comparison(
+            model_results=model_df,
+            observed_data=observed_df,
+            variables=["N", "psi"],
+        )
+
+        assert isinstance(fig, plt.Figure)
+        assert len(fig.axes) == 2
+        plt.close(fig)
+
+    def test_comparison_single_variable(self) -> None:
+        """Test comparison plot with single variable."""
+        model_df = sample_simulation_df()
+        observed_df = sample_observed_df()
+
+        fig = plots.plot_comparison(
+            model_results=model_df,
+            observed_data=observed_df,
+            variables=["psi"],
+        )
+
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_comparison_with_confidence_bands(self) -> None:
+        """Test comparison plot with confidence bands."""
+        model_df = sample_simulation_df()
+        # Add confidence band columns
+        model_df["psi_lower"] = model_df["psi"] - 0.1
+        model_df["psi_upper"] = model_df["psi"] + 0.1
+
+        observed_df = sample_observed_df()
+
+        fig = plots.plot_comparison(
+            model_results=model_df,
+            observed_data=observed_df,
+            variables=["psi"],
+            confidence_bands=True,
+            confidence_columns={"psi": ("psi_lower", "psi_upper")},
+        )
+
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_comparison_confidence_bands_without_columns_raises(self) -> None:
+        """Test that confidence_bands without columns raises ValueError."""
+        model_df = sample_simulation_df()
+        observed_df = sample_observed_df()
+
+        with pytest.raises(ValueError, match="confidence_columns required"):
+            plots.plot_comparison(
+                model_results=model_df,
+                observed_data=observed_df,
+                variables=["psi"],
+                confidence_bands=True,
+            )
+
+
+class TestSaveFigure:
+    """Tests for save_figure function."""
+
+    def test_save_png(self) -> None:
+        """Test saving figure as PNG."""
+        df = sample_simulation_df()
+        fig = plots.plot_time_series(df, variables=["N"])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "test.png"
+            saved = plots.save_figure(fig, path)
+
+            assert len(saved) == 1
+            assert saved[0].exists()
+            assert saved[0].suffix == ".png"
+
+        plt.close(fig)
+
+    def test_save_svg(self) -> None:
+        """Test saving figure as SVG."""
+        df = sample_simulation_df()
+        fig = plots.plot_time_series(df, variables=["N"])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "test.svg"
+            saved = plots.save_figure(fig, path)
+
+            assert len(saved) == 1
+            assert saved[0].exists()
+            assert saved[0].suffix == ".svg"
+
+        plt.close(fig)
+
+    def test_save_pdf(self) -> None:
+        """Test saving figure as PDF."""
+        df = sample_simulation_df()
+        fig = plots.plot_time_series(df, variables=["N"])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "test.pdf"
+            saved = plots.save_figure(fig, path)
+
+            assert len(saved) == 1
+            assert saved[0].exists()
+            assert saved[0].suffix == ".pdf"
+
+        plt.close(fig)
+
+    def test_save_multiple_formats(self) -> None:
+        """Test saving figure in multiple formats."""
+        df = sample_simulation_df()
+        fig = plots.plot_time_series(df, variables=["N"])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "test"
+            saved = plots.save_figure(fig, path, formats=["png", "svg", "pdf"])
+
+            assert len(saved) == 3
+            assert all(p.exists() for p in saved)
+            suffixes = {p.suffix for p in saved}
+            assert suffixes == {".png", ".svg", ".pdf"}
+
+        plt.close(fig)
+
+    def test_save_unsupported_format_raises(self) -> None:
+        """Test that unsupported format raises ValueError."""
+        df = sample_simulation_df()
+        fig = plots.plot_time_series(df, variables=["N"])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "test.gif"
+
+            with pytest.raises(ValueError, match="Unsupported format"):
+                plots.save_figure(fig, path)
+
+        plt.close(fig)
+
+
+class TestDetectPeaksAndTroughs:
+    """Tests for peak and trough detection."""
+
+    def test_detect_peaks_simple(self) -> None:
+        """Test peak detection on simple sinusoid."""
+        t = np.linspace(0, 4 * np.pi, 100)
+        values = np.sin(t)
+
+        peaks, troughs = cycles.detect_peaks_and_troughs(values, t)
+
+        # Should find approximately 2 peaks and 2 troughs
+        assert len(peaks) >= 1
+        assert len(troughs) >= 1
+        # Peaks should be near max value
+        assert all(p.value > 0.5 for p in peaks)
+        # Troughs should be near min value
+        assert all(p.value < -0.5 for p in troughs)
+
+    def test_detect_peaks_no_peaks(self) -> None:
+        """Test detection on monotonic data (no peaks)."""
+        values = np.linspace(0, 10, 50)
+
+        peaks, troughs = cycles.detect_peaks_and_troughs(values)
+
+        assert len(peaks) == 0
+        assert len(troughs) == 0
+
+    def test_detect_peaks_with_noise(self) -> None:
+        """Test peak detection with noisy data."""
+        np.random.seed(42)
+        t = np.linspace(0, 4 * np.pi, 200)
+        values = np.sin(t) + np.random.normal(0, 0.1, len(t))
+
+        peaks, troughs = cycles.detect_peaks_and_troughs(values, t, min_prominence=0.3)
+
+        assert len(peaks) >= 1
+        assert len(troughs) >= 1
+
+
+class TestDetectSecularCycles:
+    """Tests for secular cycle detection."""
+
+    def test_detect_cycles_simple(self) -> None:
+        """Test cycle detection on simple oscillating data."""
+        t = np.linspace(0, 300, 301)
+        psi = 0.5 + 0.4 * np.sin(2 * np.pi * t / 100)
+
+        result = cycles.detect_secular_cycles(psi, t)
+
+        assert isinstance(result, cycles.CycleDetectionResult)
+        assert len(result.cycles) >= 2
+        # Periods should be approximately 100
+        if result.mean_period is not None:
+            assert 80 < result.mean_period < 120
+
+    def test_detect_cycles_with_phases(self) -> None:
+        """Test that cycles have phase information."""
+        t = np.linspace(0, 300, 301)
+        psi = 0.5 + 0.4 * np.sin(2 * np.pi * t / 100)
+
+        result = cycles.detect_secular_cycles(psi, t)
+
+        if result.cycles:
+            cycle = result.cycles[0]
+            assert len(cycle.phases) == 4
+            phases = [p[2] for p in cycle.phases]
+            assert cycles.CyclePhase.EXPANSION in phases
+            assert cycles.CyclePhase.CRISIS in phases
+
+    def test_detect_cycles_from_dataframe(self) -> None:
+        """Test cycle detection from DataFrame column."""
+        df = sample_simulation_df()
+
+        result = cycles.detect_secular_cycles(df["psi"], df["t"])
+
+        assert isinstance(result, cycles.CycleDetectionResult)
+
+    def test_detect_cycles_minimum_length(self) -> None:
+        """Test cycle detection with minimum length filter."""
+        t = np.linspace(0, 300, 301)
+        # Mix of short and long cycles
+        psi = 0.5 + 0.4 * np.sin(2 * np.pi * t / 100)
+
+        result = cycles.detect_secular_cycles(psi, t, min_cycle_length=150)
+
+        # Only long cycles should pass filter
+        for cycle in result.cycles:
+            assert cycle.duration >= 150
+
+
+class TestPlotWithCycles:
+    """Tests for plot_with_cycles function."""
+
+    def test_basic_cycle_plot(self) -> None:
+        """Test basic cycle plotting."""
+        df = sample_simulation_df()
+        detected = cycles.detect_secular_cycles(df["psi"], df["t"])
+
+        fig = cycles.plot_with_cycles(df, detected)
+
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_cycle_plot_without_phases(self) -> None:
+        """Test cycle plot without phase shading."""
+        df = sample_simulation_df()
+        detected = cycles.detect_secular_cycles(df["psi"], df["t"])
+
+        fig = cycles.plot_with_cycles(df, detected, show_phases=False)
+
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_cycle_plot_without_markers(self) -> None:
+        """Test cycle plot without peak/trough markers."""
+        df = sample_simulation_df()
+        detected = cycles.detect_secular_cycles(df["psi"], df["t"])
+
+        fig = cycles.plot_with_cycles(
+            df, detected, show_peaks=False, show_troughs=False
+        )
+
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+
+class TestPlotCycleComparison:
+    """Tests for plot_cycle_comparison function."""
+
+    def test_cycle_comparison_plot(self) -> None:
+        """Test cycle comparison plot."""
+        df = sample_simulation_df()
+        detected = cycles.detect_secular_cycles(df["psi"], df["t"])
+
+        fig = cycles.plot_cycle_comparison(detected)
+
+        assert isinstance(fig, plt.Figure)
+        assert len(fig.axes) == 4
+        plt.close(fig)
+
+    def test_cycle_comparison_no_cycles(self) -> None:
+        """Test cycle comparison with no cycles detected."""
+        # Monotonic data with no cycles
+        result = cycles.CycleDetectionResult(cycles=[], peaks=[], troughs=[])
+
+        fig = cycles.plot_cycle_comparison(result)
+
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+
+class TestComputeCycleStatistics:
+    """Tests for compute_cycle_statistics function."""
+
+    def test_statistics_with_cycles(self) -> None:
+        """Test statistics computation with detected cycles."""
+        df = sample_simulation_df()
+        detected = cycles.detect_secular_cycles(df["psi"], df["t"])
+
+        stats = cycles.compute_cycle_statistics(detected)
+
+        assert "n_cycles" in stats
+        assert "mean_period" in stats
+        assert "mean_amplitude" in stats
+        if detected.cycles:
+            assert stats["n_cycles"] == len(detected.cycles)
+            assert stats["mean_period"] is not None
+
+    def test_statistics_no_cycles(self) -> None:
+        """Test statistics with no cycles."""
+        result = cycles.CycleDetectionResult(cycles=[], peaks=[], troughs=[])
+
+        stats = cycles.compute_cycle_statistics(result)
+
+        assert stats["n_cycles"] == 0
+        assert stats["mean_period"] is None
+
+
+class TestVariableLabels:
+    """Tests for variable labeling."""
+
+    def test_default_labels(self) -> None:
+        """Test that default labels are used."""
+        assert "N" in plots.VARIABLE_LABELS
+        assert "psi" in plots.VARIABLE_LABELS
+        assert "\u03c8" in plots.VARIABLE_LABELS["psi"]  # Greek psi
+
+    def test_default_colors(self) -> None:
+        """Test that default colors are defined."""
+        assert len(plots.DEFAULT_COLORS) >= 5
+        # Colors should be valid hex colors
+        for color in plots.DEFAULT_COLORS:
+            assert color.startswith("#")
+            assert len(color) == 7


### PR DESCRIPTION
## Summary

This PR implements Issue #9: Visualization module with reusable components for cliodynamics analysis.

**New files:**
- `src/cliodynamics/viz/plots.py`: Time series and phase space visualizations
- `src/cliodynamics/viz/cycles.py`: Secular cycle detection and visualization
- `tests/test_viz.py`: Comprehensive tests (40 test cases)

**Features:**
- **Time series plots** (`plot_time_series`): Single or multi-panel plots with customizable labels, colors, and grid
- **Phase space diagrams** (`plot_phase_space`, `plot_phase_space_3d`): 2D and 3D trajectory visualization with color coding by time
- **Model vs data comparison** (`plot_comparison`): Overlay model output with observed data, including confidence bands
- **Secular cycle detection** (`detect_secular_cycles`): Identifies cycles from trough to trough with phase classification
- **Cycle visualization** (`plot_with_cycles`, `plot_cycle_comparison`): Annotated plots showing expansion, stagflation, crisis, depression phases
- **Export support**: PNG, SVG, PDF formats via `save_figure`

**Style:**
- Matplotlib-based for publication quality
- Colorblind-friendly default palette
- Consistent styling across all plot types
- Greek symbols for psi variable

## Test plan

- [x] Run `ruff check` - passes with no errors
- [x] Run `ruff format` - all files formatted
- [x] Run `pytest tests/test_viz.py` - 40 tests pass
- [x] Run full test suite - 85 tests pass

## Example usage

```python
from cliodynamics.viz import plots, cycles

# Time series
fig = plots.plot_time_series(results, variables=['N', 'W', 'psi'])
plots.save_figure(fig, 'timeseries.png')

# Phase space
fig = plots.plot_phase_space(results, x='W', y='psi', color_by='t')

# Secular cycles
detected = cycles.detect_secular_cycles(results['psi'])
fig = cycles.plot_with_cycles(results, detected)
```

Closes #9

---
Generated with [Claude Code](https://claude.com/claude-code)