### PR TITLE
Add dimension validation to charts module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "matplotlib>=3.7",
     "requests>=2.28",
     "openpyxl>=3.1",
+    "imagesize>=1.4",
 ]
 
 [project.optional-dependencies]

--- a/src/cliodynamics/viz/charts.py
+++ b/src/cliodynamics/viz/charts.py
@@ -7,16 +7,38 @@ to maintain quality standards.
 
 IMPORTANT: After generating any chart, visually verify it looks correct
 before committing. Charts must be readable and properly formatted.
+
+Known Failure Modes:
+--------------------
+1. Runaway Chart Height: Charts can export with extreme dimensions (e.g., 53,000px)
+   due to unknown Altair/Vega interactions. This module validates dimensions
+   and warns/fails when charts exceed reasonable bounds.
+
+2. Missing/Corrupt Export: File created but empty or corrupt. The verify_chart()
+   function checks file size and dimensions.
+
+3. Text Cutoff: Labels truncated at chart edges. Use labelLimit parameter.
+
+4. Unreadable Fonts: Default Altair fonts are too small. This module enforces
+   minimum font sizes for readability.
 """
 
 from __future__ import annotations
 
 import logging
+import tempfile
 from pathlib import Path
+from shutil import move
 from typing import Any
 
 import altair as alt
 import pandas as pd
+
+try:
+    import imagesize
+    HAS_IMAGESIZE = True
+except ImportError:
+    HAS_IMAGESIZE = False
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +48,10 @@ CHART_HEIGHT_SMALL = 400
 CHART_HEIGHT_MEDIUM = 600
 CHART_HEIGHT_LARGE = 900
 CHART_HEIGHT_XLARGE = 1200  # For charts with many categories
+
+# Maximum allowed dimensions (safeguard against runaway charts)
+MAX_CHART_WIDTH = 3000
+MAX_CHART_HEIGHT = 3000
 
 # Standard font sizes (minimum for readability)
 FONT_SIZE_TITLE = 20
@@ -38,23 +64,169 @@ FONT_SIZE_LEGEND_TITLE = 14
 PNG_SCALE_FACTOR = 2
 
 
+class ChartDimensionError(Exception):
+    """Raised when a chart exceeds maximum allowed dimensions."""
+    pass
+
+
+class ChartValidationResult:
+    """Result of chart dimension validation."""
+
+    def __init__(
+        self,
+        width: int,
+        height: int,
+        file_size: int,
+        is_valid: bool,
+        message: str,
+    ):
+        self.width = width
+        self.height = height
+        self.file_size = file_size
+        self.is_valid = is_valid
+        self.message = message
+
+    def __repr__(self) -> str:
+        status = "VALID" if self.is_valid else "INVALID"
+        return (
+            f"ChartValidationResult({status}: {self.width}x{self.height}px, "
+            f"{self.file_size:,} bytes - {self.message})"
+        )
+
+
+def validate_chart_dimensions(
+    path: str | Path,
+    max_width: int = MAX_CHART_WIDTH,
+    max_height: int = MAX_CHART_HEIGHT,
+) -> ChartValidationResult:
+    """
+    Validate that a saved chart has reasonable dimensions.
+
+    Uses the lightweight imagesize library to check PNG dimensions without
+    loading the full image into memory.
+
+    Args:
+        path: Path to the saved chart image
+        max_width: Maximum allowed width in pixels
+        max_height: Maximum allowed height in pixels
+
+    Returns:
+        ChartValidationResult with dimensions, validity, and message
+
+    Raises:
+        FileNotFoundError: If chart file does not exist
+
+    Example:
+        >>> result = validate_chart_dimensions("chart.png")
+        >>> if not result.is_valid:
+        ...     print(f"Warning: {result.message}")
+    """
+    path = Path(path)
+
+    if not path.exists():
+        raise FileNotFoundError(f"Chart file not found: {path}")
+
+    file_size = path.stat().st_size
+
+    # Check file size first
+    if file_size < 1000:
+        return ChartValidationResult(
+            width=0,
+            height=0,
+            file_size=file_size,
+            is_valid=False,
+            message=f"File too small ({file_size} bytes) - likely corrupt or empty",
+        )
+
+    if file_size > 50_000_000:  # 50MB
+        return ChartValidationResult(
+            width=0,
+            height=0,
+            file_size=file_size,
+            is_valid=False,
+            message=f"File too large ({file_size:,} bytes) - likely corrupted",
+        )
+
+    # Get dimensions
+    if not HAS_IMAGESIZE:
+        logger.warning(
+            "imagesize library not installed - skipping dimension validation. "
+            "Install with: pip install imagesize"
+        )
+        return ChartValidationResult(
+            width=0,
+            height=0,
+            file_size=file_size,
+            is_valid=True,
+            message="Dimension validation skipped (imagesize not installed)",
+        )
+
+    try:
+        width, height = imagesize.get(str(path))
+    except Exception as e:
+        return ChartValidationResult(
+            width=0,
+            height=0,
+            file_size=file_size,
+            is_valid=False,
+            message=f"Failed to read image dimensions: {e}",
+        )
+
+    # Check if dimensions are valid (imagesize returns -1, -1 for unknown formats)
+    if width < 0 or height < 0:
+        return ChartValidationResult(
+            width=width,
+            height=height,
+            file_size=file_size,
+            is_valid=False,
+            message="Could not determine image dimensions",
+        )
+
+    # Check against maximums
+    issues = []
+    if width > max_width:
+        issues.append(f"width {width}px exceeds max {max_width}px")
+    if height > max_height:
+        issues.append(f"height {height}px exceeds max {max_height}px")
+
+    if issues:
+        return ChartValidationResult(
+            width=width,
+            height=height,
+            file_size=file_size,
+            is_valid=False,
+            message=f"Chart too large: {', '.join(issues)}",
+        )
+
+    return ChartValidationResult(
+        width=width,
+        height=height,
+        file_size=file_size,
+        is_valid=True,
+        message=f"Dimensions OK: {width}x{height}px",
+    )
+
+
 def configure_chart(
     chart: alt.Chart,
     title: str,
     width: int = CHART_WIDTH,
     height: int = CHART_HEIGHT_MEDIUM,
+    max_height: int = MAX_CHART_HEIGHT,
 ) -> alt.Chart:
     """
     Apply standard formatting to an Altair chart.
 
     This ensures all charts have readable fonts, proper dimensions,
-    and consistent styling.
+    and consistent styling. Height is clamped to max_height to prevent
+    runaway chart dimensions.
 
     Args:
         chart: The Altair chart to configure
         title: Chart title
         width: Chart width in pixels
         height: Chart height in pixels
+        max_height: Maximum allowed height (default 3000px)
 
     Returns:
         Configured chart ready for export
@@ -64,6 +236,13 @@ def configure_chart(
         >>> chart = configure_chart(chart, "My Chart Title", height=900)
         >>> save_chart(chart, "output.png")
     """
+    # Clamp height to maximum
+    if height > max_height:
+        logger.warning(
+            f"Requested height {height}px exceeds max {max_height}px, clamping"
+        )
+        height = max_height
+
     return (
         chart
         .properties(
@@ -95,35 +274,121 @@ def save_chart(
     chart: alt.Chart,
     path: str | Path,
     scale_factor: int = PNG_SCALE_FACTOR,
+    max_width: int = MAX_CHART_WIDTH,
+    max_height: int = MAX_CHART_HEIGHT,
+    validate: bool = True,
+    debug: bool = False,
 ) -> Path:
     """
-    Save chart to file with proper resolution.
+    Save chart to file with proper resolution and dimension validation.
+
+    For PNG files, the chart is first saved to a temporary file, validated,
+    and only moved to the final path if dimensions are within bounds.
 
     Args:
         chart: Configured Altair chart
         path: Output file path (.png, .svg, or .html)
         scale_factor: Resolution multiplier for PNG (default 2x)
+        max_width: Maximum allowed width in pixels (for PNG validation)
+        max_height: Maximum allowed height in pixels (for PNG validation)
+        validate: Whether to validate dimensions (default True, PNG only)
+        debug: If True, print chart spec and save HTML alongside PNG
 
     Returns:
         Path to saved file
 
     Raises:
         ValueError: If file format not supported
+        ChartDimensionError: If PNG dimensions exceed maximums and validate=True
     """
     path = Path(path)
     suffix = path.suffix.lower()
 
+    if debug:
+        _print_chart_debug_info(chart)
+
     if suffix == '.png':
-        chart.save(str(path), scale_factor=scale_factor)
+        if validate:
+            # Save to temp file first for validation
+            with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as tmp:
+                tmp_path = Path(tmp.name)
+
+            try:
+                chart.save(str(tmp_path), scale_factor=scale_factor)
+                result = validate_chart_dimensions(tmp_path, max_width, max_height)
+
+                if not result.is_valid:
+                    tmp_path.unlink()  # Clean up temp file
+                    raise ChartDimensionError(
+                        f"Chart dimension validation failed: {result.message}. "
+                        f"File: {path}"
+                    )
+
+                # Validation passed, move to final location
+                path.parent.mkdir(parents=True, exist_ok=True)
+                move(str(tmp_path), str(path))
+                logger.info(
+                    f"Chart saved to {path} ({result.width}x{result.height}px, "
+                    f"{result.file_size:,} bytes)"
+                )
+            except ChartDimensionError:
+                raise
+            except Exception as e:
+                if tmp_path.exists():
+                    tmp_path.unlink()
+                raise RuntimeError(f"Failed to save chart: {e}") from e
+        else:
+            # Save directly without validation
+            chart.save(str(path), scale_factor=scale_factor)
+            logger.info(f"Chart saved to {path} (validation skipped)")
+
+        # Optionally save HTML for debugging
+        if debug:
+            html_path = path.with_suffix('.html')
+            chart.save(str(html_path))
+            logger.info(f"Debug HTML saved to {html_path}")
+
     elif suffix == '.svg':
         chart.save(str(path))
+        logger.info(f"Chart saved to {path}")
     elif suffix == '.html':
         chart.save(str(path))
+        logger.info(f"Chart saved to {path}")
     else:
         raise ValueError(f"Unsupported format: {suffix}. Use .png, .svg, or .html")
 
-    logger.info(f"Chart saved to {path}")
     return path
+
+
+def _print_chart_debug_info(chart: alt.Chart) -> None:
+    """Print debug information about a chart."""
+    try:
+        spec = chart.to_dict()
+        print("=" * 60)
+        print("CHART DEBUG INFO")
+        print("=" * 60)
+
+        # Print dimensions if available
+        if 'width' in spec:
+            print(f"Width: {spec['width']}")
+        if 'height' in spec:
+            print(f"Height: {spec['height']}")
+
+        # Print data summary if available
+        if 'data' in spec and 'values' in spec['data']:
+            data = spec['data']['values']
+            if isinstance(data, list):
+                print(f"Data rows: {len(data)}")
+                if data:
+                    print(f"Data columns: {list(data[0].keys())}")
+
+        # Print encoding summary
+        if 'encoding' in spec:
+            print(f"Encodings: {list(spec['encoding'].keys())}")
+
+        print("=" * 60)
+    except Exception as e:
+        print(f"Could not extract debug info: {e}")
 
 
 def create_timeline_chart(
@@ -133,11 +398,13 @@ def create_timeline_chart(
     end_column: str,
     color_column: str | None = None,
     title: str = "Timeline",
+    max_height: int = MAX_CHART_HEIGHT,
 ) -> alt.Chart:
     """
     Create a horizontal bar timeline chart.
 
-    Automatically sizes height based on number of categories.
+    Automatically sizes height based on number of categories, with a
+    maximum height safeguard.
 
     Args:
         df: DataFrame with timeline data
@@ -146,6 +413,7 @@ def create_timeline_chart(
         end_column: Column for bar end (e.g., end year)
         color_column: Optional column for color encoding
         title: Chart title
+        max_height: Maximum chart height (default 3000px)
 
     Returns:
         Configured chart ready for export
@@ -155,6 +423,14 @@ def create_timeline_chart(
     # Scale height based on number of categories
     # Minimum 20px per category, plus padding
     height = max(CHART_HEIGHT_MEDIUM, n_categories * 25 + 100)
+
+    # Apply max height safeguard
+    if height > max_height:
+        logger.warning(
+            f"Timeline chart would be {height}px tall for {n_categories} categories. "
+            f"Clamping to {max_height}px. Consider filtering data."
+        )
+        height = max_height
 
     encoding: dict[str, Any] = {
         'y': alt.Y(f'{y_column}:N', title=None, sort=None),
@@ -170,7 +446,7 @@ def create_timeline_chart(
 
     chart = alt.Chart(df).mark_bar().encode(**encoding)
 
-    return configure_chart(chart, title, height=height)
+    return configure_chart(chart, title, height=height, max_height=max_height)
 
 
 def create_line_chart(
@@ -213,6 +489,7 @@ def create_bar_chart(
     color_column: str | None = None,
     title: str = "Bar Chart",
     horizontal: bool = False,
+    max_height: int = MAX_CHART_HEIGHT,
 ) -> alt.Chart:
     """
     Create a bar chart.
@@ -224,6 +501,7 @@ def create_bar_chart(
         color_column: Optional column for color
         title: Chart title
         horizontal: If True, create horizontal bars
+        max_height: Maximum chart height for horizontal bars
 
     Returns:
         Configured chart ready for export
@@ -231,6 +509,12 @@ def create_bar_chart(
     if horizontal:
         n_categories = df[y_column].nunique()
         height = max(CHART_HEIGHT_SMALL, n_categories * 25 + 100)
+        if height > max_height:
+            logger.warning(
+                f"Bar chart would be {height}px tall for {n_categories} categories. "
+                f"Clamping to {max_height}px."
+            )
+            height = max_height
         encoding = {
             'y': alt.Y(f'{y_column}:N', title=None, sort='-x'),
             'x': alt.X(f'{x_column}:Q', title=x_column.replace('_', ' ').title()),
@@ -247,7 +531,7 @@ def create_bar_chart(
 
     chart = alt.Chart(df).mark_bar().encode(**encoding)
 
-    return configure_chart(chart, title, height=height)
+    return configure_chart(chart, title, height=height, max_height=max_height)
 
 
 def create_heatmap(
@@ -256,6 +540,7 @@ def create_heatmap(
     y_column: str,
     color_column: str,
     title: str = "Heatmap",
+    max_height: int = MAX_CHART_HEIGHT,
 ) -> alt.Chart:
     """
     Create a heatmap visualization.
@@ -266,6 +551,7 @@ def create_heatmap(
         y_column: Column for Y-axis categories
         color_column: Column for color intensity
         title: Chart title
+        max_height: Maximum chart height
 
     Returns:
         Configured chart ready for export
@@ -273,13 +559,20 @@ def create_heatmap(
     n_y_categories = df[y_column].nunique()
     height = max(CHART_HEIGHT_MEDIUM, n_y_categories * 20 + 100)
 
+    if height > max_height:
+        logger.warning(
+            f"Heatmap would be {height}px tall. Clamping to {max_height}px."
+        )
+        height = max_height
+
+    color_title = color_column.replace('_', ' ').title()
     chart = alt.Chart(df).mark_rect().encode(
         x=alt.X(f'{x_column}:N', title=None),
         y=alt.Y(f'{y_column}:N', title=None),
-        color=alt.Color(f'{color_column}:Q', title=color_column.replace('_', ' ').title()),
+        color=alt.Color(f'{color_column}:Q', title=color_title),
     )
 
-    return configure_chart(chart, title, height=height)
+    return configure_chart(chart, title, height=height, max_height=max_height)
 
 
 # Verification reminder
@@ -298,7 +591,11 @@ VERIFICATION_REMINDER = """
 
 
 def verify_chart_exists(path: str | Path) -> bool:
-    """Check if a chart file exists and has reasonable size."""
+    """
+    Check if a chart file exists and has reasonable size.
+
+    Deprecated: Use verify_chart() for comprehensive validation.
+    """
     path = Path(path)
     if not path.exists():
         logger.error(f"Chart not found: {path}")
@@ -312,3 +609,55 @@ def verify_chart_exists(path: str | Path) -> bool:
     logger.info(f"Chart exists: {path} ({size:,} bytes)")
     print(VERIFICATION_REMINDER)
     return True
+
+
+def verify_chart(
+    path: str | Path,
+    max_width: int = MAX_CHART_WIDTH,
+    max_height: int = MAX_CHART_HEIGHT,
+    print_info: bool = True,
+) -> ChartValidationResult:
+    """
+    Comprehensive chart verification with dimension reporting.
+
+    This is the recommended way to verify charts after generation.
+    It checks file existence, size, and dimensions.
+
+    Args:
+        path: Path to the chart file
+        max_width: Maximum allowed width in pixels
+        max_height: Maximum allowed height in pixels
+        print_info: Whether to print verification info to console
+
+    Returns:
+        ChartValidationResult with full details
+
+    Example:
+        >>> save_chart(chart, "output.png")
+        >>> result = verify_chart("output.png")
+        >>> if not result.is_valid:
+        ...     print(f"Chart verification failed: {result.message}")
+    """
+    path = Path(path)
+
+    if not path.exists():
+        result = ChartValidationResult(
+            width=0,
+            height=0,
+            file_size=0,
+            is_valid=False,
+            message=f"File not found: {path}",
+        )
+        if print_info:
+            print(f"[FAIL] {result.message}")
+        return result
+
+    result = validate_chart_dimensions(path, max_width, max_height)
+
+    if print_info:
+        status = "[OK]" if result.is_valid else "[FAIL]"
+        print(f"{status} {path.name}: {result.message}")
+        if result.is_valid:
+            print(VERIFICATION_REMINDER)
+
+    return result

--- a/tests/viz/test_charts.py
+++ b/tests/viz/test_charts.py
@@ -1,0 +1,430 @@
+"""Tests for the charts module dimension validation and safeguards."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from cliodynamics.viz import charts
+
+
+class TestChartValidationResult:
+    """Tests for ChartValidationResult class."""
+
+    def test_valid_result(self):
+        """Test creating a valid result."""
+        result = charts.ChartValidationResult(
+            width=800,
+            height=600,
+            file_size=50000,
+            is_valid=True,
+            message="Dimensions OK",
+        )
+        assert result.width == 800
+        assert result.height == 600
+        assert result.file_size == 50000
+        assert result.is_valid is True
+        assert "Dimensions OK" in result.message
+
+    def test_invalid_result(self):
+        """Test creating an invalid result."""
+        result = charts.ChartValidationResult(
+            width=5000,
+            height=3000,
+            file_size=100000,
+            is_valid=False,
+            message="width exceeds max",
+        )
+        assert result.is_valid is False
+        assert "width exceeds max" in result.message
+
+    def test_repr(self):
+        """Test string representation."""
+        result = charts.ChartValidationResult(
+            width=800,
+            height=600,
+            file_size=50000,
+            is_valid=True,
+            message="OK",
+        )
+        repr_str = repr(result)
+        assert "VALID" in repr_str
+        assert "800x600" in repr_str
+
+        invalid_result = charts.ChartValidationResult(
+            width=5000,
+            height=3000,
+            file_size=100000,
+            is_valid=False,
+            message="too large",
+        )
+        assert "INVALID" in repr(invalid_result)
+
+
+class TestValidateChartDimensions:
+    """Tests for validate_chart_dimensions function."""
+
+    def test_file_not_found(self, tmp_path):
+        """Test with non-existent file."""
+        with pytest.raises(FileNotFoundError):
+            charts.validate_chart_dimensions(tmp_path / "nonexistent.png")
+
+    def test_file_too_small(self, tmp_path):
+        """Test detection of too-small files."""
+        small_file = tmp_path / "small.png"
+        small_file.write_bytes(b"x" * 100)  # 100 bytes
+
+        result = charts.validate_chart_dimensions(small_file)
+        assert result.is_valid is False
+        assert "too small" in result.message.lower()
+
+    def test_file_too_large(self, tmp_path):
+        """Test detection of too-large files."""
+        large_file = tmp_path / "large.png"
+        # Create a file larger than 50MB threshold
+        large_file.write_bytes(b"x" * 51_000_000)
+
+        result = charts.validate_chart_dimensions(large_file)
+        assert result.is_valid is False
+        assert "too large" in result.message.lower()
+
+    @patch("cliodynamics.viz.charts.HAS_IMAGESIZE", False)
+    def test_without_imagesize(self, tmp_path):
+        """Test fallback when imagesize not installed."""
+        # Create a file with reasonable size
+        test_file = tmp_path / "test.png"
+        test_file.write_bytes(b"x" * 10000)
+
+        result = charts.validate_chart_dimensions(test_file)
+        # Should return valid with warning message
+        assert result.is_valid is True
+        assert "skipped" in result.message.lower()
+
+    @patch("cliodynamics.viz.charts.imagesize")
+    def test_valid_dimensions(self, mock_imagesize, tmp_path):
+        """Test with valid dimensions."""
+        mock_imagesize.get.return_value = (800, 600)
+
+        test_file = tmp_path / "valid.png"
+        test_file.write_bytes(b"x" * 10000)
+
+        result = charts.validate_chart_dimensions(test_file)
+        assert result.is_valid is True
+        assert result.width == 800
+        assert result.height == 600
+
+    @patch("cliodynamics.viz.charts.imagesize")
+    def test_dimensions_exceed_max_width(self, mock_imagesize, tmp_path):
+        """Test detection of width exceeding maximum."""
+        mock_imagesize.get.return_value = (5000, 600)
+
+        test_file = tmp_path / "wide.png"
+        test_file.write_bytes(b"x" * 10000)
+
+        result = charts.validate_chart_dimensions(test_file, max_width=3000)
+        assert result.is_valid is False
+        assert "width" in result.message.lower()
+        assert "5000" in result.message
+
+    @patch("cliodynamics.viz.charts.imagesize")
+    def test_dimensions_exceed_max_height(self, mock_imagesize, tmp_path):
+        """Test detection of height exceeding maximum."""
+        mock_imagesize.get.return_value = (800, 53000)
+
+        test_file = tmp_path / "tall.png"
+        test_file.write_bytes(b"x" * 10000)
+
+        result = charts.validate_chart_dimensions(test_file, max_height=3000)
+        assert result.is_valid is False
+        assert "height" in result.message.lower()
+        assert "53000" in result.message
+
+    @patch("cliodynamics.viz.charts.imagesize")
+    def test_dimensions_exceed_both(self, mock_imagesize, tmp_path):
+        """Test detection when both dimensions exceed max."""
+        mock_imagesize.get.return_value = (5000, 6000)
+
+        test_file = tmp_path / "huge.png"
+        test_file.write_bytes(b"x" * 10000)
+
+        result = charts.validate_chart_dimensions(
+            test_file, max_width=3000, max_height=3000
+        )
+        assert result.is_valid is False
+        assert "width" in result.message.lower()
+        assert "height" in result.message.lower()
+
+    @patch("cliodynamics.viz.charts.imagesize")
+    def test_custom_max_dimensions(self, mock_imagesize, tmp_path):
+        """Test with custom maximum dimensions."""
+        mock_imagesize.get.return_value = (1000, 1000)
+
+        test_file = tmp_path / "custom.png"
+        test_file.write_bytes(b"x" * 10000)
+
+        # Should pass with default max (3000)
+        result = charts.validate_chart_dimensions(test_file)
+        assert result.is_valid is True
+
+        # Should fail with stricter max
+        result = charts.validate_chart_dimensions(
+            test_file, max_width=500, max_height=500
+        )
+        assert result.is_valid is False
+
+
+class TestConfigureChart:
+    """Tests for configure_chart function."""
+
+    def test_height_clamping(self):
+        """Test that height is clamped to max_height."""
+        df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+        import altair as alt
+
+        chart = alt.Chart(df).mark_bar().encode(x="x", y="y")
+
+        # Request height exceeding max
+        configured = charts.configure_chart(
+            chart, "Test", height=5000, max_height=2000
+        )
+
+        # Check that height was clamped (extract from chart spec)
+        spec = configured.to_dict()
+        assert spec["height"] == 2000
+
+    def test_default_max_height(self):
+        """Test default max height is applied."""
+        df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+        import altair as alt
+
+        chart = alt.Chart(df).mark_bar().encode(x="x", y="y")
+
+        configured = charts.configure_chart(chart, "Test", height=600)
+        spec = configured.to_dict()
+        assert spec["height"] == 600  # Should not be clamped
+
+
+class TestSaveChart:
+    """Tests for save_chart function."""
+
+    def test_unsupported_format(self, tmp_path):
+        """Test error on unsupported format."""
+        df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+        import altair as alt
+
+        chart = alt.Chart(df).mark_bar().encode(x="x", y="y")
+
+        with pytest.raises(ValueError, match="Unsupported format"):
+            charts.save_chart(chart, tmp_path / "output.xyz")
+
+    @patch("cliodynamics.viz.charts.validate_chart_dimensions")
+    def test_validation_failure_raises_error(self, mock_validate, tmp_path):
+        """Test that validation failure raises ChartDimensionError."""
+        mock_validate.return_value = charts.ChartValidationResult(
+            width=800,
+            height=53000,
+            file_size=10000,
+            is_valid=False,
+            message="height exceeds max",
+        )
+
+        df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+        import altair as alt
+
+        chart = alt.Chart(df).mark_bar().encode(x="x", y="y")
+        configured = charts.configure_chart(chart, "Test")
+
+        with pytest.raises(charts.ChartDimensionError):
+            charts.save_chart(configured, tmp_path / "output.png")
+
+    def test_save_without_validation(self, tmp_path):
+        """Test saving without validation."""
+        df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+        import altair as alt
+
+        chart = alt.Chart(df).mark_bar().encode(x="x", y="y")
+        configured = charts.configure_chart(chart, "Test")
+
+        # Should not raise even without validation
+        path = charts.save_chart(
+            configured, tmp_path / "output.png", validate=False
+        )
+        assert path.exists()
+
+    def test_save_html(self, tmp_path):
+        """Test saving as HTML (no validation needed)."""
+        df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+        import altair as alt
+
+        chart = alt.Chart(df).mark_bar().encode(x="x", y="y")
+        configured = charts.configure_chart(chart, "Test")
+
+        path = charts.save_chart(configured, tmp_path / "output.html")
+        assert path.exists()
+        assert path.suffix == ".html"
+
+    def test_save_svg(self, tmp_path):
+        """Test saving as SVG (no validation needed)."""
+        df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+        import altair as alt
+
+        chart = alt.Chart(df).mark_bar().encode(x="x", y="y")
+        configured = charts.configure_chart(chart, "Test")
+
+        path = charts.save_chart(configured, tmp_path / "output.svg")
+        assert path.exists()
+        assert path.suffix == ".svg"
+
+
+class TestCreateTimelineChart:
+    """Tests for create_timeline_chart function."""
+
+    def test_height_safeguard(self):
+        """Test that timeline chart height is clamped."""
+        # Create DataFrame with many categories
+        n_categories = 200
+        df = pd.DataFrame({
+            "name": [f"item_{i}" for i in range(n_categories)],
+            "start": list(range(n_categories)),
+            "end": list(range(1, n_categories + 1)),
+        })
+
+        chart = charts.create_timeline_chart(
+            df, "name", "start", "end", title="Test", max_height=2000
+        )
+
+        spec = chart.to_dict()
+        assert spec["height"] <= 2000
+
+
+class TestCreateBarChart:
+    """Tests for create_bar_chart function."""
+
+    def test_horizontal_bar_height_safeguard(self):
+        """Test that horizontal bar chart height is clamped."""
+        n_categories = 200
+        df = pd.DataFrame({
+            "category": [f"cat_{i}" for i in range(n_categories)],
+            "value": list(range(n_categories)),
+        })
+
+        chart = charts.create_bar_chart(
+            df, "value", "category", horizontal=True, max_height=1500
+        )
+
+        spec = chart.to_dict()
+        assert spec["height"] <= 1500
+
+
+class TestCreateHeatmap:
+    """Tests for create_heatmap function."""
+
+    def test_height_safeguard(self):
+        """Test that heatmap height is clamped."""
+        n_y_categories = 200
+        df = pd.DataFrame({
+            "x": ["A"] * n_y_categories,
+            "y": [f"y_{i}" for i in range(n_y_categories)],
+            "value": list(range(n_y_categories)),
+        })
+
+        chart = charts.create_heatmap(
+            df, "x", "y", "value", title="Test", max_height=1500
+        )
+
+        spec = chart.to_dict()
+        assert spec["height"] <= 1500
+
+
+class TestVerifyChart:
+    """Tests for verify_chart function."""
+
+    def test_file_not_found(self, tmp_path, capsys):
+        """Test with non-existent file."""
+        result = charts.verify_chart(tmp_path / "nonexistent.png")
+        assert result.is_valid is False
+        assert "not found" in result.message.lower()
+
+        captured = capsys.readouterr()
+        assert "[FAIL]" in captured.out
+
+    @patch("cliodynamics.viz.charts.validate_chart_dimensions")
+    def test_valid_chart(self, mock_validate, tmp_path, capsys):
+        """Test with valid chart."""
+        mock_validate.return_value = charts.ChartValidationResult(
+            width=800,
+            height=600,
+            file_size=50000,
+            is_valid=True,
+            message="Dimensions OK",
+        )
+
+        test_file = tmp_path / "valid.png"
+        test_file.write_bytes(b"x" * 10000)
+
+        result = charts.verify_chart(test_file)
+        assert result.is_valid is True
+
+        captured = capsys.readouterr()
+        assert "[OK]" in captured.out
+        assert charts.VERIFICATION_REMINDER in captured.out
+
+    def test_print_info_disabled(self, tmp_path, capsys):
+        """Test that print_info=False suppresses output."""
+        test_file = tmp_path / "test.png"
+        test_file.write_bytes(b"x" * 10000)
+
+        with patch("cliodynamics.viz.charts.validate_chart_dimensions") as mock:
+            mock.return_value = charts.ChartValidationResult(
+                width=800, height=600, file_size=50000,
+                is_valid=True, message="OK"
+            )
+            charts.verify_chart(test_file, print_info=False)
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+
+class TestChartDimensionError:
+    """Tests for ChartDimensionError exception."""
+
+    def test_exception_message(self):
+        """Test exception can be raised with message."""
+        with pytest.raises(charts.ChartDimensionError, match="too large"):
+            raise charts.ChartDimensionError("Chart is too large")
+
+
+class TestDebugMode:
+    """Tests for debug mode functionality."""
+
+    def test_print_chart_debug_info(self, capsys):
+        """Test debug info printing."""
+        df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+        import altair as alt
+
+        chart = alt.Chart(df).mark_bar().encode(x="x", y="y")
+        configured = charts.configure_chart(chart, "Test", width=800, height=600)
+
+        charts._print_chart_debug_info(configured)
+
+        captured = capsys.readouterr()
+        assert "CHART DEBUG INFO" in captured.out
+        assert "Width" in captured.out or "Height" in captured.out
+
+
+class TestModuleConstants:
+    """Tests for module constants."""
+
+    def test_max_dimensions_defined(self):
+        """Test that max dimension constants are defined."""
+        assert charts.MAX_CHART_WIDTH == 3000
+        assert charts.MAX_CHART_HEIGHT == 3000
+
+    def test_chart_heights_defined(self):
+        """Test that standard height constants are defined."""
+        assert charts.CHART_HEIGHT_SMALL == 400
+        assert charts.CHART_HEIGHT_MEDIUM == 600
+        assert charts.CHART_HEIGHT_LARGE == 900
+        assert charts.CHART_HEIGHT_XLARGE == 1200


### PR DESCRIPTION
## Summary

Adds safeguards to prevent and detect oversized chart outputs like the 53,000px tall chart bug:

- Add `validate_chart_dimensions()` function using lightweight `imagesize` library
- Add `ChartDimensionError` exception and `ChartValidationResult` class for structured validation results
- Update `save_chart()` to validate PNG dimensions before final save (saves to temp file first)
- Add `max_height` parameter to `configure_chart()` and all chart creation functions (default 3000px)
- Add comprehensive `verify_chart()` with dimension reporting
- Add debug mode option for troubleshooting chart issues
- Add `imagesize>=1.4` dependency to pyproject.toml

## Test plan

- [x] Run `pytest tests/viz/test_charts.py` - 29 tests pass
- [x] Run `ruff check` - all checks pass
- [ ] Verify existing chart generation scripts still work
- [ ] Test with an oversized chart to confirm validation catches it

Closes #49

Generated with [Claude Code](https://claude.com/claude-code)