### PR TITLE
Add policy simulation framework

### DIFF
--- a/src/cliodynamics/policy/__init__.py
+++ b/src/cliodynamics/policy/__init__.py
@@ -1,0 +1,98 @@
+"""Policy simulation framework for counterfactual analysis.
+
+This module provides tools for simulating policy interventions and
+extracting actionable recommendations from SDT models. It enables
+"what-if" analysis: given a historical trajectory, what policies
+might have changed outcomes?
+
+Key Components:
+- Interventions: Define policy actions (elite caps, wage floors, etc.)
+- Counterfactual engine: Run simulations with interventions applied
+- Analysis: Compare outcomes and identify effective policies
+
+Example:
+    >>> from cliodynamics.policy import (
+    ...     Intervention, EliteCap, WageFloor,
+    ...     CounterfactualEngine, OutcomeComparison
+    ... )
+    >>> from cliodynamics.models import SDTModel, SDTParams
+    >>> from cliodynamics.simulation import Simulator, SimulationResult
+    >>>
+    >>> # Run baseline simulation
+    >>> model = SDTModel(SDTParams())
+    >>> sim = Simulator(model)
+    >>> baseline = sim.run(
+    ...     {'N': 0.5, 'E': 0.05, 'W': 1.0, 'S': 1.0, 'psi': 0.0},
+    ...     time_span=(0, 200)
+    ... )
+    >>>
+    >>> # Define intervention: cap elite growth at year 50
+    >>> intervention = EliteCap(
+    ...     start_time=50,
+    ...     max_elite_ratio=1.5,  # max 1.5x baseline
+    ...     name="Elite cap at year 50"
+    ... )
+    >>>
+    >>> # Run counterfactual
+    >>> engine = CounterfactualEngine(model)
+    >>> result = engine.run_intervention(baseline, intervention)
+    >>>
+    >>> # Compare outcomes
+    >>> comparison = OutcomeComparison(baseline, result)
+    >>> print(comparison.psi_peak_reduction())
+
+References:
+    Turchin, P. (2016). Ages of Discord, Chapter 10: "What Can We Do?"
+    Turchin, P. & Nefedov, S. (2009). Secular Cycles, Conclusion.
+"""
+
+from cliodynamics.policy.analysis import (
+    OutcomeComparison,
+    PolicyRecommendation,
+    SensitivityAnalysis,
+    recommend_interventions,
+)
+from cliodynamics.policy.counterfactual import (
+    CounterfactualEngine,
+    CounterfactualResult,
+    InterventionModel,
+)
+from cliodynamics.policy.interventions import (
+    CompositeIntervention,
+    EliteCap,
+    ElitePurge,
+    FiscalAusterity,
+    FiscalStimulus,
+    FrontierExpansion,
+    InstitutionalReform,
+    Intervention,
+    MigrationControl,
+    TaxProgressivity,
+    WageBoost,
+    WageFloor,
+)
+
+__all__ = [
+    # Interventions
+    "Intervention",
+    "EliteCap",
+    "ElitePurge",
+    "WageFloor",
+    "WageBoost",
+    "TaxProgressivity",
+    "FiscalAusterity",
+    "FiscalStimulus",
+    "MigrationControl",
+    "FrontierExpansion",
+    "InstitutionalReform",
+    "CompositeIntervention",
+    # Counterfactual engine
+    "CounterfactualEngine",
+    "CounterfactualResult",
+    "InterventionModel",
+    # Analysis
+    "OutcomeComparison",
+    "SensitivityAnalysis",
+    "PolicyRecommendation",
+    "recommend_interventions",
+]

--- a/src/cliodynamics/policy/analysis.py
+++ b/src/cliodynamics/policy/analysis.py
@@ -1,0 +1,778 @@
+"""Analysis tools for comparing counterfactual outcomes.
+
+This module provides tools for analyzing and comparing results from
+counterfactual simulations, including:
+
+- OutcomeComparison: Compare metrics between baseline and intervention
+- SensitivityAnalysis: Measure which interventions have largest effects
+- PolicyRecommendation: Rank interventions by effectiveness
+
+Example:
+    >>> from cliodynamics.policy import OutcomeComparison, SensitivityAnalysis
+    >>>
+    >>> # Compare baseline and intervention
+    >>> comparison = OutcomeComparison(baseline, intervention_result)
+    >>> print(f"PSI reduction: {comparison.psi_peak_reduction():.1%}")
+    >>>
+    >>> # Analyze sensitivity to different interventions
+    >>> analysis = SensitivityAnalysis(baseline, [result1, result2, result3])
+    >>> ranking = analysis.rank_by_psi_reduction()
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Callable
+
+import numpy as np
+import pandas as pd
+
+if TYPE_CHECKING:
+    from cliodynamics.policy.counterfactual import CounterfactualResult
+    from cliodynamics.policy.interventions import Intervention
+
+
+@dataclass
+class OutcomeMetrics:
+    """Container for key outcome metrics from a simulation.
+
+    Attributes:
+        psi_peak: Maximum PSI value.
+        psi_peak_time: Time at PSI peak.
+        psi_final: Final PSI value.
+        psi_integral: Integral of PSI over time (cumulative instability).
+        collapse_time: Time when S < 0.1 (if occurred).
+        recovery_time: Time from peak PSI to PSI < 0.1 (if occurred).
+        wage_minimum: Minimum wage value.
+        elite_maximum: Maximum elite population.
+        state_minimum: Minimum state fiscal health.
+    """
+
+    psi_peak: float
+    psi_peak_time: float
+    psi_final: float
+    psi_integral: float
+    collapse_time: float | None
+    recovery_time: float | None
+    wage_minimum: float
+    elite_maximum: float
+    state_minimum: float
+
+    @classmethod
+    def from_result(cls, result: "CounterfactualResult") -> "OutcomeMetrics":
+        """Compute metrics from a CounterfactualResult.
+
+        Args:
+            result: The simulation result to analyze.
+
+        Returns:
+            OutcomeMetrics instance.
+        """
+        df = result.df
+
+        # PSI metrics
+        psi_peak = float(df["psi"].max())
+        psi_peak_idx = df["psi"].idxmax()
+        psi_peak_time = float(df.loc[psi_peak_idx, "t"])
+        psi_final = float(df["psi"].iloc[-1])
+
+        # Integral using trapezoidal rule
+        psi_integral = float(np.trapezoid(df["psi"], df["t"]))
+
+        # Collapse detection (S < 0.1)
+        collapse_mask = df["S"] < 0.1
+        if collapse_mask.any():
+            collapse_time = float(df.loc[collapse_mask.idxmax(), "t"])
+        else:
+            collapse_time = None
+
+        # Recovery time (from peak to PSI < 0.1)
+        post_peak = df[df["t"] >= psi_peak_time]
+        recovery_mask = post_peak["psi"] < 0.1
+        if recovery_mask.any():
+            recovery_end = float(post_peak.loc[recovery_mask.idxmax(), "t"])
+            recovery_time = recovery_end - psi_peak_time
+        else:
+            recovery_time = None
+
+        return cls(
+            psi_peak=psi_peak,
+            psi_peak_time=psi_peak_time,
+            psi_final=psi_final,
+            psi_integral=psi_integral,
+            collapse_time=collapse_time,
+            recovery_time=recovery_time,
+            wage_minimum=float(df["W"].min()),
+            elite_maximum=float(df["E"].max()),
+            state_minimum=float(df["S"].min()),
+        )
+
+
+@dataclass
+class OutcomeComparison:
+    """Compare outcomes between baseline and intervention scenarios.
+
+    Provides methods for computing the effect of an intervention
+    on various outcome metrics.
+
+    Attributes:
+        baseline: The baseline CounterfactualResult.
+        intervention: The intervention CounterfactualResult.
+        baseline_metrics: Computed metrics for baseline.
+        intervention_metrics: Computed metrics for intervention.
+    """
+
+    baseline: "CounterfactualResult"
+    intervention: "CounterfactualResult"
+    baseline_metrics: OutcomeMetrics = field(init=False)
+    intervention_metrics: OutcomeMetrics = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Compute metrics for both scenarios."""
+        self.baseline_metrics = OutcomeMetrics.from_result(self.baseline)
+        self.intervention_metrics = OutcomeMetrics.from_result(self.intervention)
+
+    def psi_peak_reduction(self) -> float:
+        """Compute fractional reduction in PSI peak.
+
+        Returns:
+            Fraction by which PSI peak was reduced (positive = improvement).
+        """
+        base = self.baseline_metrics.psi_peak
+        interv = self.intervention_metrics.psi_peak
+        if base == 0:
+            return 0.0
+        return (base - interv) / base
+
+    def psi_peak_delay(self) -> float:
+        """Compute delay in PSI peak time.
+
+        Returns:
+            Time delay (positive = intervention delays crisis).
+        """
+        return (
+            self.intervention_metrics.psi_peak_time
+            - self.baseline_metrics.psi_peak_time
+        )
+
+    def psi_integral_reduction(self) -> float:
+        """Compute fractional reduction in cumulative instability.
+
+        Returns:
+            Fraction by which PSI integral was reduced.
+        """
+        base = self.baseline_metrics.psi_integral
+        interv = self.intervention_metrics.psi_integral
+        if base == 0:
+            return 0.0
+        return (base - interv) / base
+
+    def collapse_prevented(self) -> bool:
+        """Check if intervention prevented collapse.
+
+        Returns:
+            True if baseline collapsed but intervention did not.
+        """
+        return (
+            self.baseline_metrics.collapse_time is not None
+            and self.intervention_metrics.collapse_time is None
+        )
+
+    def collapse_delayed(self) -> float | None:
+        """Compute delay in collapse time.
+
+        Returns:
+            Time delay if both collapsed, None otherwise.
+        """
+        base = self.baseline_metrics.collapse_time
+        interv = self.intervention_metrics.collapse_time
+        if base is not None and interv is not None:
+            return interv - base
+        return None
+
+    def recovery_speedup(self) -> float | None:
+        """Compute speedup in recovery time.
+
+        Returns:
+            Time saved in recovery (positive = faster recovery).
+        """
+        base = self.baseline_metrics.recovery_time
+        interv = self.intervention_metrics.recovery_time
+        if base is not None and interv is not None:
+            return base - interv
+        return None
+
+    def wage_improvement(self) -> float:
+        """Compute improvement in minimum wage.
+
+        Returns:
+            Fractional improvement (positive = higher wage floor).
+        """
+        base = self.baseline_metrics.wage_minimum
+        interv = self.intervention_metrics.wage_minimum
+        if base == 0:
+            return 0.0
+        return (interv - base) / base
+
+    def state_improvement(self) -> float:
+        """Compute improvement in minimum state health.
+
+        Returns:
+            Fractional improvement (positive = stronger state).
+        """
+        base = self.baseline_metrics.state_minimum
+        interv = self.intervention_metrics.state_minimum
+        if base == 0:
+            return 0.0
+        return (interv - base) / base
+
+    def trajectory_difference(self, variable: str = "psi") -> pd.DataFrame:
+        """Compute difference in trajectories.
+
+        Args:
+            variable: Variable to compare (N, E, W, S, or psi).
+
+        Returns:
+            DataFrame with time, baseline, intervention, and difference.
+        """
+        df_base = self.baseline.df
+        df_int = self.intervention.df
+
+        # Interpolate to common time grid
+        t_min = max(df_base["t"].min(), df_int["t"].min())
+        t_max = min(df_base["t"].max(), df_int["t"].max())
+        t_common = np.linspace(t_min, t_max, 200)
+
+        base_vals = np.interp(t_common, df_base["t"], df_base[variable])
+        int_vals = np.interp(t_common, df_int["t"], df_int[variable])
+
+        return pd.DataFrame(
+            {
+                "t": t_common,
+                "baseline": base_vals,
+                "intervention": int_vals,
+                "difference": int_vals - base_vals,
+            }
+        )
+
+    def summary(self) -> str:
+        """Generate a human-readable comparison summary.
+
+        Returns:
+            Formatted string with key comparisons.
+        """
+        intervention_name = (
+            self.intervention.intervention.name
+            if self.intervention.intervention
+            else "N/A"
+        )
+        base_peak = self.baseline_metrics.psi_peak
+        base_peak_time = self.baseline_metrics.psi_peak_time
+        int_peak = self.intervention_metrics.psi_peak
+        int_peak_time = self.intervention_metrics.psi_peak_time
+
+        lines = [
+            "Outcome Comparison",
+            "=" * 50,
+            f"Intervention: {intervention_name}",
+            "",
+            "PSI Metrics:",
+            f"  Peak reduction: {self.psi_peak_reduction():.1%}",
+            f"  Peak delay: {self.psi_peak_delay():.1f} time units",
+            f"  Cumulative reduction: {self.psi_integral_reduction():.1%}",
+            "",
+            f"  Baseline peak: {base_peak:.3f} at t={base_peak_time:.1f}",
+            f"  Intervention peak: {int_peak:.3f} at t={int_peak_time:.1f}",
+            "",
+            "Collapse:",
+            f"  Prevented: {self.collapse_prevented()}",
+        ]
+
+        delay = self.collapse_delayed()
+        if delay is not None:
+            lines.append(f"  Delayed by: {delay:.1f} time units")
+
+        lines.extend(
+            [
+                "",
+                "Other Improvements:",
+                f"  Wage floor: {self.wage_improvement():.1%}",
+                f"  State minimum: {self.state_improvement():.1%}",
+            ]
+        )
+
+        return "\n".join(lines)
+
+
+@dataclass
+class SensitivityAnalysis:
+    """Analyze sensitivity of outcomes to different interventions.
+
+    Compare multiple interventions against the same baseline to
+    identify which policies have the largest effects.
+
+    Attributes:
+        baseline: The baseline CounterfactualResult.
+        results: List of intervention CounterfactualResults.
+        comparisons: Computed comparisons for each intervention.
+    """
+
+    baseline: "CounterfactualResult"
+    results: list["CounterfactualResult"]
+    comparisons: list[OutcomeComparison] = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Compute comparisons for all interventions."""
+        self.comparisons = [
+            OutcomeComparison(self.baseline, result) for result in self.results
+        ]
+
+    def rank_by_psi_reduction(self) -> list[tuple[str, float, "CounterfactualResult"]]:
+        """Rank interventions by PSI peak reduction.
+
+        Returns:
+            List of (intervention_name, reduction, result) tuples,
+            sorted by reduction (highest first).
+        """
+        ranked = []
+        for comparison, result in zip(self.comparisons, self.results):
+            name = result.intervention.name if result.intervention else "Unknown"
+            reduction = comparison.psi_peak_reduction()
+            ranked.append((name, reduction, result))
+
+        return sorted(ranked, key=lambda x: x[1], reverse=True)
+
+    def rank_by_integral_reduction(
+        self,
+    ) -> list[tuple[str, float, "CounterfactualResult"]]:
+        """Rank interventions by cumulative instability reduction.
+
+        Returns:
+            List of (intervention_name, reduction, result) tuples.
+        """
+        ranked = []
+        for comparison, result in zip(self.comparisons, self.results):
+            name = result.intervention.name if result.intervention else "Unknown"
+            reduction = comparison.psi_integral_reduction()
+            ranked.append((name, reduction, result))
+
+        return sorted(ranked, key=lambda x: x[1], reverse=True)
+
+    def find_point_of_no_return(
+        self,
+        intervention_factory: Callable[[float], "Intervention"],
+        time_points: list[float],
+        threshold: float = 0.1,
+    ) -> float | None:
+        """Find the point after which interventions become ineffective.
+
+        Tests an intervention at different times to find when it
+        no longer reduces PSI peak by at least the threshold.
+
+        Args:
+            intervention_factory: Function(start_time) -> Intervention.
+            time_points: Times to test.
+            threshold: Minimum PSI reduction to consider effective.
+
+        Returns:
+            Time of point of no return, or None if always effective.
+        """
+        for t in sorted(time_points):
+            # Find result with intervention starting near this time
+            matching = None
+            for result in self.results:
+                if result.intervention and abs(result.intervention.start_time - t) < 1:
+                    matching = result
+                    break
+
+            if matching is None:
+                continue
+
+            comparison = OutcomeComparison(self.baseline, matching)
+            if comparison.psi_peak_reduction() < threshold:
+                return t
+
+        return None
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Convert analysis to a DataFrame.
+
+        Returns:
+            DataFrame with one row per intervention and metric columns.
+        """
+        rows = []
+        for comparison, result in zip(self.comparisons, self.results):
+            name = result.intervention.name if result.intervention else "Baseline"
+            start = result.intervention.start_time if result.intervention else None
+
+            rows.append(
+                {
+                    "intervention": name,
+                    "start_time": start,
+                    "psi_peak_reduction": comparison.psi_peak_reduction(),
+                    "psi_integral_reduction": comparison.psi_integral_reduction(),
+                    "psi_peak_delay": comparison.psi_peak_delay(),
+                    "collapse_prevented": comparison.collapse_prevented(),
+                    "wage_improvement": comparison.wage_improvement(),
+                    "state_improvement": comparison.state_improvement(),
+                    "baseline_psi_peak": comparison.baseline_metrics.psi_peak,
+                    "intervention_psi_peak": comparison.intervention_metrics.psi_peak,
+                }
+            )
+
+        return pd.DataFrame(rows)
+
+    def summary(self) -> str:
+        """Generate summary of sensitivity analysis.
+
+        Returns:
+            Formatted string with rankings and key findings.
+        """
+        baseline_psi = OutcomeMetrics.from_result(self.baseline).psi_peak
+        lines = [
+            "Sensitivity Analysis",
+            "=" * 60,
+            f"Baseline PSI peak: {baseline_psi:.3f}",
+            f"Number of interventions tested: {len(self.results)}",
+            "",
+            "Ranked by PSI Peak Reduction:",
+            "-" * 40,
+        ]
+
+        for i, (name, reduction, _) in enumerate(self.rank_by_psi_reduction()[:10]):
+            lines.append(f"  {i + 1}. {name}: {reduction:.1%}")
+
+        lines.extend(
+            [
+                "",
+                "Ranked by Cumulative Instability Reduction:",
+                "-" * 40,
+            ]
+        )
+
+        for i, (name, reduction, _) in enumerate(
+            self.rank_by_integral_reduction()[:10]
+        ):
+            lines.append(f"  {i + 1}. {name}: {reduction:.1%}")
+
+        return "\n".join(lines)
+
+
+@dataclass
+class PolicyRecommendation:
+    """A policy recommendation with justification.
+
+    Attributes:
+        intervention: The recommended intervention.
+        effectiveness: PSI peak reduction achieved.
+        timing: Recommended start time.
+        confidence: Confidence level (0-1).
+        rationale: Explanation of why this is recommended.
+        trade_offs: List of potential downsides.
+        historical_precedents: Historical examples of similar policies.
+    """
+
+    intervention: "Intervention"
+    effectiveness: float
+    timing: float
+    confidence: float
+    rationale: str
+    trade_offs: list[str] = field(default_factory=list)
+    historical_precedents: list[str] = field(default_factory=list)
+
+    def summary(self) -> str:
+        """Generate recommendation summary.
+
+        Returns:
+            Formatted string with recommendation details.
+        """
+        lines = [
+            f"Policy Recommendation: {self.intervention.name}",
+            "=" * 60,
+            f"Effectiveness: {self.effectiveness:.1%} PSI reduction",
+            f"Optimal timing: t = {self.timing:.1f}",
+            f"Confidence: {self.confidence:.0%}",
+            "",
+            "Rationale:",
+            f"  {self.rationale}",
+        ]
+
+        if self.trade_offs:
+            lines.extend(["", "Trade-offs:"])
+            for trade_off in self.trade_offs:
+                lines.append(f"  - {trade_off}")
+
+        if self.historical_precedents:
+            lines.extend(["", "Historical precedents:"])
+            for precedent in self.historical_precedents:
+                lines.append(f"  - {precedent}")
+
+        return "\n".join(lines)
+
+
+def recommend_interventions(
+    baseline: "CounterfactualResult",
+    intervention_results: list["CounterfactualResult"],
+    objective: str = "minimize_psi_peak",
+    constraints: list[str] | None = None,
+    max_recommendations: int = 5,
+) -> list[PolicyRecommendation]:
+    """Generate ranked policy recommendations.
+
+    Analyzes intervention results and generates recommendations
+    based on effectiveness and constraints.
+
+    Args:
+        baseline: The baseline CounterfactualResult.
+        intervention_results: Results from tested interventions.
+        objective: What to optimize:
+            - "minimize_psi_peak": Reduce peak instability
+            - "minimize_psi_integral": Reduce cumulative instability
+            - "prevent_collapse": Avoid state fiscal crisis
+        constraints: List of constraints to apply:
+            - "economically_viable": Avoid severe economic disruption
+            - "politically_feasible": Limit radical changes
+        max_recommendations: Maximum number of recommendations.
+
+    Returns:
+        List of PolicyRecommendation objects, ranked by effectiveness.
+    """
+    constraints = constraints or []
+    analysis = SensitivityAnalysis(baseline, intervention_results)
+
+    # Rank by objective
+    if objective == "minimize_psi_peak":
+        ranked = analysis.rank_by_psi_reduction()
+    elif objective == "minimize_psi_integral":
+        ranked = analysis.rank_by_integral_reduction()
+    elif objective == "prevent_collapse":
+        # Filter to those that prevent collapse, then rank by PSI reduction
+        ranked = [
+            (name, reduction, result)
+            for name, reduction, result in analysis.rank_by_psi_reduction()
+            if OutcomeComparison(baseline, result).collapse_prevented()
+            or OutcomeMetrics.from_result(baseline).collapse_time is None
+        ]
+    else:
+        raise ValueError(f"Unknown objective: {objective}")
+
+    # Apply constraints (simplified filtering)
+    if "economically_viable" in constraints:
+        # Filter out interventions with wage boost > 5% or extreme changes
+        ranked = [
+            (name, reduction, result)
+            for name, reduction, result in ranked
+            if not _is_economically_extreme(result.intervention)
+        ]
+
+    if "politically_feasible" in constraints:
+        # Filter out purges and other radical interventions
+        ranked = [
+            (name, reduction, result)
+            for name, reduction, result in ranked
+            if not _is_politically_radical(result.intervention)
+        ]
+
+    # Generate recommendations
+    recommendations = []
+    for name, reduction, result in ranked[:max_recommendations]:
+        intervention = result.intervention
+        if intervention is None:
+            continue
+
+        # Generate rationale based on intervention type
+        rationale = _generate_rationale(intervention, reduction)
+        trade_offs = _identify_trade_offs(intervention, result, baseline)
+        precedents = _find_historical_precedents(intervention)
+
+        recommendations.append(
+            PolicyRecommendation(
+                intervention=intervention,
+                effectiveness=reduction,
+                timing=intervention.start_time,
+                confidence=_estimate_confidence(reduction, len(intervention_results)),
+                rationale=rationale,
+                trade_offs=trade_offs,
+                historical_precedents=precedents,
+            )
+        )
+
+    return recommendations
+
+
+def _is_economically_extreme(intervention: "Intervention | None") -> bool:
+    """Check if intervention is economically extreme."""
+    if intervention is None:
+        return False
+
+    from cliodynamics.policy.interventions import ElitePurge, WageBoost
+
+    if isinstance(intervention, WageBoost) and intervention.boost_rate > 0.05:
+        return True
+    if isinstance(intervention, ElitePurge) and intervention.reduction_fraction > 0.3:
+        return True
+    return False
+
+
+def _is_politically_radical(intervention: "Intervention | None") -> bool:
+    """Check if intervention is politically radical."""
+    if intervention is None:
+        return False
+
+    from cliodynamics.policy.interventions import ElitePurge
+
+    if isinstance(intervention, ElitePurge):
+        return True
+    return False
+
+
+def _generate_rationale(intervention: "Intervention", effectiveness: float) -> str:
+    """Generate explanation for why intervention is effective."""
+    from cliodynamics.policy.interventions import (
+        EliteCap,
+        FiscalStimulus,
+        InstitutionalReform,
+        TaxProgressivity,
+        WageFloor,
+    )
+
+    if isinstance(intervention, EliteCap):
+        return (
+            f"Capping elite growth prevents overproduction that drives "
+            f"intra-elite competition, reducing instability by {effectiveness:.0%}."
+        )
+    elif isinstance(intervention, WageFloor):
+        return (
+            f"Maintaining minimum wages prevents popular immiseration, "
+            f"a key driver of instability, achieving {effectiveness:.0%} reduction."
+        )
+    elif isinstance(intervention, TaxProgressivity):
+        return (
+            f"Progressive taxation redistributes resources from elites to state, "
+            f"strengthening fiscal capacity and reducing PSI by {effectiveness:.0%}."
+        )
+    elif isinstance(intervention, FiscalStimulus):
+        return (
+            f"State-funded welfare programs directly address popular grievances, "
+            f"achieving {effectiveness:.0%} PSI reduction."
+        )
+    elif isinstance(intervention, InstitutionalReform):
+        return (
+            f"Institutional reforms improve legitimacy and governance efficiency, "
+            f"yielding {effectiveness:.0%} reduction in instability."
+        )
+    else:
+        return f"This intervention achieves {effectiveness:.0%} PSI reduction."
+
+
+def _identify_trade_offs(
+    intervention: "Intervention",
+    result: "CounterfactualResult",
+    baseline: "CounterfactualResult",
+) -> list[str]:
+    """Identify potential downsides of the intervention."""
+    trade_offs = []
+
+    comparison = OutcomeComparison(baseline, result)
+
+    # Check if any metric got worse
+    if comparison.wage_improvement() < -0.05:
+        trade_offs.append("May reduce wage levels in short term")
+
+    if comparison.state_improvement() < -0.05:
+        trade_offs.append("May strain state fiscal capacity")
+
+    from cliodynamics.policy.interventions import (
+        EliteCap,
+        FiscalAusterity,
+        TaxProgressivity,
+    )
+
+    if isinstance(intervention, EliteCap):
+        trade_offs.append("May reduce economic dynamism and innovation")
+        trade_offs.append("Requires sustained enforcement against elite resistance")
+
+    if isinstance(intervention, TaxProgressivity):
+        trade_offs.append("May face political opposition from wealthy elites")
+        trade_offs.append("Could trigger capital flight")
+
+    if isinstance(intervention, FiscalAusterity):
+        trade_offs.append("May worsen popular welfare in short term")
+        trade_offs.append("Could trigger social unrest if perceived as unfair")
+
+    return trade_offs
+
+
+def _find_historical_precedents(intervention: "Intervention") -> list[str]:
+    """Find historical examples of similar policies."""
+    from cliodynamics.policy.interventions import (
+        EliteCap,
+        ElitePurge,
+        FiscalStimulus,
+        FrontierExpansion,
+        InstitutionalReform,
+        TaxProgressivity,
+        WageFloor,
+    )
+
+    if isinstance(intervention, EliteCap):
+        return [
+            "Roman Lex Claudia (218 BCE) - restricted senatorial commerce",
+            "Medieval guild restrictions on master craftsmen",
+            "Modern professional licensing requirements",
+        ]
+    elif isinstance(intervention, ElitePurge):
+        return [
+            "Roman proscriptions under Sulla and Second Triumvirate",
+            "French Revolution's Reign of Terror",
+            "Russian Revolution - dispossession of nobility",
+        ]
+    elif isinstance(intervention, WageFloor):
+        return [
+            "Medieval just price doctrines",
+            "New Deal minimum wage (1938)",
+            "Post-WWII labor accords in Western Europe",
+        ]
+    elif isinstance(intervention, TaxProgressivity):
+        return [
+            "Roman tribute distributions",
+            "British income tax (1799, reintroduced 1842)",
+            "Progressive income tax (US 1913, peak rates 1950s)",
+        ]
+    elif isinstance(intervention, FiscalStimulus):
+        return [
+            "Roman grain doles (annona)",
+            "New Deal public works programs",
+            "Post-2008 stimulus packages",
+        ]
+    elif isinstance(intervention, FrontierExpansion):
+        return [
+            "Roman colonization during Republic",
+            "American westward expansion (19th century)",
+            "European colonial expansion (16th-19th century)",
+        ]
+    elif isinstance(intervention, InstitutionalReform):
+        return [
+            "Augustan constitutional settlement (27 BCE)",
+            "British Reform Acts (1832, 1867, 1884)",
+            "New Deal institutional reforms (1930s)",
+        ]
+    else:
+        return []
+
+
+def _estimate_confidence(effectiveness: float, n_samples: int) -> float:
+    """Estimate confidence in the recommendation."""
+    # Simple heuristic: higher effectiveness and more samples = more confidence
+    base_confidence = min(0.9, effectiveness * 2)  # Cap at 90%
+    sample_factor = min(1.0, n_samples / 10)  # Approaches 1 with 10+ samples
+    return base_confidence * sample_factor
+
+
+__all__ = [
+    "OutcomeMetrics",
+    "OutcomeComparison",
+    "SensitivityAnalysis",
+    "PolicyRecommendation",
+    "recommend_interventions",
+]

--- a/src/cliodynamics/policy/counterfactual.py
+++ b/src/cliodynamics/policy/counterfactual.py
@@ -1,0 +1,486 @@
+"""Counterfactual simulation engine for policy analysis.
+
+This module provides the core simulation infrastructure for running
+counterfactual scenarios with policy interventions applied.
+
+The CounterfactualEngine wraps the standard Simulator to apply
+interventions during integration, allowing comparison of trajectories
+with and without policy changes.
+
+Example:
+    >>> from cliodynamics.policy import CounterfactualEngine, EliteCap
+    >>> from cliodynamics.models import SDTModel, SDTParams
+    >>>
+    >>> model = SDTModel(SDTParams())
+    >>> engine = CounterfactualEngine(model)
+    >>>
+    >>> # Get baseline result
+    >>> baseline = engine.run_baseline(
+    ...     {'N': 0.5, 'E': 0.05, 'W': 1.0, 'S': 1.0, 'psi': 0.0},
+    ...     time_span=(0, 200)
+    ... )
+    >>>
+    >>> # Run counterfactual with elite cap
+    >>> intervention = EliteCap(name="Elite cap", start_time=50, max_elite_ratio=1.5)
+    >>> result = engine.run_intervention(baseline, intervention)
+    >>>
+    >>> # Compare PSI peaks
+    >>> print(f"Baseline PSI peak: {baseline.result.df['psi'].max():.2f}")
+    >>> print(f"Intervention PSI peak: {result.result.df['psi'].max():.2f}")
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import pandas as pd
+from numpy.typing import ArrayLike, NDArray
+from scipy.integrate import solve_ivp
+
+if TYPE_CHECKING:
+    from cliodynamics.models import SDTModel
+    from cliodynamics.models.params import SDTParams
+    from cliodynamics.simulation import SimulationResult
+
+from cliodynamics.policy.interventions import Intervention
+
+
+@dataclass
+class CounterfactualResult:
+    """Container for counterfactual simulation results.
+
+    Attributes:
+        result: The SimulationResult from the counterfactual run.
+        intervention: The intervention that was applied (or None for baseline).
+        baseline_reference: Reference to the baseline CounterfactualResult
+            if this is an intervention run.
+        intervention_start_state: State at intervention start time.
+        metadata: Additional metadata about the run.
+    """
+
+    result: "SimulationResult"
+    intervention: Intervention | None = None
+    baseline_reference: "CounterfactualResult | None" = None
+    intervention_start_state: dict[str, float] | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def df(self) -> pd.DataFrame:
+        """Access the results DataFrame."""
+        return self.result.df
+
+    @property
+    def is_baseline(self) -> bool:
+        """Check if this is a baseline (no intervention) result."""
+        return self.intervention is None
+
+    @property
+    def psi_peak(self) -> float:
+        """Maximum PSI value in the trajectory."""
+        return float(self.result.df["psi"].max())
+
+    @property
+    def psi_peak_time(self) -> float:
+        """Time at which PSI reaches maximum."""
+        df = self.result.df
+        return float(df.loc[df["psi"].idxmax(), "t"])
+
+    @property
+    def final_state(self) -> dict[str, float]:
+        """State at the end of simulation."""
+        return self.result.final_state
+
+    def state_at_time(self, t: float) -> dict[str, float]:
+        """Get interpolated state at a specific time.
+
+        Args:
+            t: Time to query.
+
+        Returns:
+            Dictionary of state variables at time t.
+        """
+        df = self.result.df
+        state = {}
+        for col in ["N", "E", "W", "S", "psi"]:
+            if col in df.columns:
+                state[col] = float(np.interp(t, df["t"], df[col]))
+        return state
+
+
+class InterventionModel:
+    """SDT model wrapper that applies interventions during simulation.
+
+    This class wraps an SDTModel and modifies its dynamics according
+    to active interventions. It implements the same interface as SDTModel
+    so it can be used with the Simulator.
+
+    Attributes:
+        base_model: The underlying SDTModel.
+        interventions: List of active interventions.
+    """
+
+    def __init__(
+        self,
+        base_model: "SDTModel",
+        interventions: list[Intervention] | None = None,
+    ) -> None:
+        """Initialize the intervention model.
+
+        Args:
+            base_model: The SDTModel to wrap.
+            interventions: List of interventions to apply.
+        """
+        self.base_model = base_model
+        self.interventions = interventions or []
+
+    @property
+    def params(self) -> "SDTParams":
+        """Access the underlying model parameters."""
+        return self.base_model.params
+
+    def system(self, y: ArrayLike, t: float) -> NDArray[np.float64]:
+        """Compute system derivatives with interventions applied.
+
+        First applies state modifications, then computes derivatives,
+        then applies derivative modifications.
+
+        Args:
+            y: Current state vector [N, E, W, S, psi].
+            t: Current time.
+
+        Returns:
+            Modified derivatives.
+        """
+        state = np.array(y, dtype=np.float64)
+
+        # Apply state modifications from interventions
+        for intervention in self.interventions:
+            state = intervention.modify_state(state, t, self.params)
+
+        # Compute base derivatives
+        derivatives = self.base_model.system(state, t)
+
+        # Apply derivative modifications from interventions
+        for intervention in self.interventions:
+            derivatives = intervention.modify_derivatives(
+                derivatives, state, t, self.params
+            )
+
+        return derivatives
+
+
+class CounterfactualEngine:
+    """Engine for running counterfactual policy simulations.
+
+    The engine provides methods for:
+    - Running baseline simulations
+    - Applying interventions at specified times
+    - Comparing trajectories between scenarios
+    - Batch simulation of multiple interventions
+
+    Attributes:
+        model: The SDTModel to use for simulations.
+        state_names: Names of state variables.
+    """
+
+    DEFAULT_STATE_NAMES = ("N", "E", "W", "S", "psi")
+
+    def __init__(
+        self,
+        model: "SDTModel",
+        state_names: tuple[str, ...] | None = None,
+    ) -> None:
+        """Initialize the counterfactual engine.
+
+        Args:
+            model: SDTModel to use for simulations.
+            state_names: Names of state variables.
+        """
+        self.model = model
+        self.state_names = state_names or self.DEFAULT_STATE_NAMES
+
+    def run_baseline(
+        self,
+        initial_conditions: dict[str, float],
+        time_span: tuple[float, float],
+        dt: float = 1.0,
+        method: str = "RK45",
+        **kwargs: Any,
+    ) -> CounterfactualResult:
+        """Run a baseline simulation without interventions.
+
+        Args:
+            initial_conditions: Initial state dictionary.
+            time_span: (start_time, end_time) tuple.
+            dt: Output time step.
+            method: ODE solver method.
+            **kwargs: Additional arguments for solve_ivp.
+
+        Returns:
+            CounterfactualResult for the baseline trajectory.
+        """
+        from cliodynamics.simulation import Simulator
+
+        sim = Simulator(self.model, state_names=self.state_names)
+        result = sim.run(
+            initial_conditions=initial_conditions,
+            time_span=time_span,
+            dt=dt,
+            method=method,
+            **kwargs,
+        )
+
+        return CounterfactualResult(
+            result=result,
+            intervention=None,
+            baseline_reference=None,
+            metadata={
+                "initial_conditions": initial_conditions.copy(),
+                "time_span": time_span,
+                "dt": dt,
+                "method": method,
+            },
+        )
+
+    def run_intervention(
+        self,
+        baseline: CounterfactualResult,
+        intervention: Intervention,
+        dt: float | None = None,
+        method: str | None = None,
+        **kwargs: Any,
+    ) -> CounterfactualResult:
+        """Run a counterfactual with an intervention applied.
+
+        The simulation uses the same initial conditions and time span
+        as the baseline, but with the intervention modifying dynamics.
+
+        Args:
+            baseline: The baseline CounterfactualResult to compare against.
+            intervention: The intervention to apply.
+            dt: Output time step (defaults to baseline's dt).
+            method: ODE solver method (defaults to baseline's method).
+            **kwargs: Additional arguments for solve_ivp.
+
+        Returns:
+            CounterfactualResult for the intervention scenario.
+        """
+        # Get baseline parameters
+        meta = baseline.metadata
+        initial_conditions = meta.get("initial_conditions", baseline.final_state)
+        time_span = meta.get("time_span", (0.0, 200.0))
+        dt = dt or meta.get("dt", 1.0)
+        method = method or meta.get("method", "RK45")
+
+        # Create intervention model
+        intervention_model = InterventionModel(self.model, [intervention])
+
+        # Run simulation using solve_ivp directly
+        y0 = np.array([initial_conditions[name] for name in self.state_names])
+        t_start, t_end = time_span
+        t_eval = np.arange(t_start, t_end + dt, dt)
+        t_eval = t_eval[t_eval <= t_end]
+
+        def system(t: float, y: NDArray[np.float64]) -> NDArray[np.float64]:
+            return intervention_model.system(y, t)
+
+        solution = solve_ivp(
+            system,
+            time_span,
+            y0,
+            method=method,
+            t_eval=t_eval,
+            **kwargs,
+        )
+
+        # Build DataFrame
+        data = {"t": solution.t}
+        for i, name in enumerate(self.state_names):
+            data[name] = solution.y[i]
+        df = pd.DataFrame(data)
+
+        # Create SimulationResult-like object
+        from cliodynamics.simulation import SimulationResult
+
+        result = SimulationResult(
+            df=df,
+            events=[],
+            terminated_by_event=False,
+            solver_message=solution.message,
+        )
+
+        # Get state at intervention start
+        intervention_start_state = None
+        if intervention.start_time >= time_span[0]:
+            intervention_start_state = baseline.state_at_time(intervention.start_time)
+
+        return CounterfactualResult(
+            result=result,
+            intervention=intervention,
+            baseline_reference=baseline,
+            intervention_start_state=intervention_start_state,
+            metadata={
+                "initial_conditions": initial_conditions.copy(),
+                "time_span": time_span,
+                "dt": dt,
+                "method": method,
+            },
+        )
+
+    def run_interventions(
+        self,
+        baseline: CounterfactualResult,
+        interventions: list[Intervention],
+        dt: float | None = None,
+        method: str | None = None,
+        **kwargs: Any,
+    ) -> list[CounterfactualResult]:
+        """Run multiple interventions against the same baseline.
+
+        Args:
+            baseline: The baseline CounterfactualResult.
+            interventions: List of interventions to test.
+            dt: Output time step.
+            method: ODE solver method.
+            **kwargs: Additional arguments for solve_ivp.
+
+        Returns:
+            List of CounterfactualResults, one per intervention.
+        """
+        results = []
+        for intervention in interventions:
+            result = self.run_intervention(
+                baseline, intervention, dt=dt, method=method, **kwargs
+            )
+            results.append(result)
+        return results
+
+    def run_from_state(
+        self,
+        state: dict[str, float],
+        time_span: tuple[float, float],
+        intervention: Intervention | None = None,
+        dt: float = 1.0,
+        method: str = "RK45",
+        **kwargs: Any,
+    ) -> CounterfactualResult:
+        """Run simulation from a specified state.
+
+        Useful for branching simulations: run baseline until time T,
+        then branch with an intervention from that point.
+
+        Args:
+            state: State dictionary to start from.
+            time_span: (start_time, end_time) tuple.
+            intervention: Optional intervention to apply.
+            dt: Output time step.
+            method: ODE solver method.
+            **kwargs: Additional arguments for solve_ivp.
+
+        Returns:
+            CounterfactualResult for the trajectory.
+        """
+        if intervention is None:
+            return self.run_baseline(
+                initial_conditions=state,
+                time_span=time_span,
+                dt=dt,
+                method=method,
+                **kwargs,
+            )
+
+        # Create intervention model
+        intervention_model = InterventionModel(self.model, [intervention])
+
+        # Run simulation
+        y0 = np.array([state[name] for name in self.state_names])
+        t_start, t_end = time_span
+        t_eval = np.arange(t_start, t_end + dt, dt)
+        t_eval = t_eval[t_eval <= t_end]
+
+        def system(t: float, y: NDArray[np.float64]) -> NDArray[np.float64]:
+            return intervention_model.system(y, t)
+
+        solution = solve_ivp(
+            system,
+            time_span,
+            y0,
+            method=method,
+            t_eval=t_eval,
+            **kwargs,
+        )
+
+        # Build DataFrame
+        data = {"t": solution.t}
+        for i, name in enumerate(self.state_names):
+            data[name] = solution.y[i]
+        df = pd.DataFrame(data)
+
+        from cliodynamics.simulation import SimulationResult
+
+        result = SimulationResult(
+            df=df,
+            events=[],
+            terminated_by_event=False,
+            solver_message=solution.message,
+        )
+
+        return CounterfactualResult(
+            result=result,
+            intervention=intervention,
+            baseline_reference=None,
+            intervention_start_state=state.copy(),
+            metadata={
+                "initial_conditions": state.copy(),
+                "time_span": time_span,
+                "dt": dt,
+                "method": method,
+            },
+        )
+
+    def find_intervention_timing(
+        self,
+        baseline: CounterfactualResult,
+        intervention_factory: Any,  # Callable[[float], Intervention]
+        start_times: list[float],
+        metric: str = "psi_peak",
+    ) -> dict[float, tuple[float, CounterfactualResult]]:
+        """Find optimal intervention timing.
+
+        Tests an intervention applied at different times to find
+        when it is most effective.
+
+        Args:
+            baseline: The baseline CounterfactualResult.
+            intervention_factory: Function(start_time) -> Intervention.
+            start_times: List of start times to test.
+            metric: Metric to optimize ("psi_peak" or "final_psi").
+
+        Returns:
+            Dictionary mapping start_time to (metric_value, result).
+        """
+        results: dict[float, tuple[float, CounterfactualResult]] = {}
+
+        for start_time in start_times:
+            intervention = intervention_factory(start_time)
+            result = self.run_intervention(baseline, intervention)
+
+            if metric == "psi_peak":
+                value = result.psi_peak
+            elif metric == "final_psi":
+                value = result.df["psi"].iloc[-1]
+            else:
+                raise ValueError(f"Unknown metric: {metric}")
+
+            results[start_time] = (value, result)
+
+        return results
+
+
+__all__ = [
+    "CounterfactualEngine",
+    "CounterfactualResult",
+    "InterventionModel",
+]

--- a/src/cliodynamics/policy/interventions.py
+++ b/src/cliodynamics/policy/interventions.py
@@ -1,0 +1,857 @@
+"""Policy intervention types for counterfactual analysis.
+
+This module defines various policy interventions that can be applied
+to SDT simulations to explore counterfactual scenarios.
+
+Interventions modify the dynamics of the system at specified times,
+allowing exploration of questions like:
+- "What if Rome had capped elite growth in 100 BCE?"
+- "What if US wages had tracked productivity since 1970?"
+
+Intervention Categories:
+1. Elite Management: caps, purges, co-optation, credentialing
+2. Popular Welfare: wage floors, land reform, labor rights
+3. Fiscal Policy: taxation, spending, debt
+4. Demographics: migration, frontier expansion
+5. Institutions: democratic reform, representation
+
+Each intervention specifies:
+- When it activates (start_time, end_time)
+- What it modifies (target variable or parameter)
+- How it modifies (absolute value, multiplier, cap, floor)
+
+Example:
+    >>> intervention = EliteCap(
+    ...     start_time=100,
+    ...     max_elite_ratio=1.5,
+    ...     name="Cap elite growth to 1.5x baseline"
+    ... )
+    >>> # Intervention activates at t=100 and prevents E from exceeding 1.5*E_0
+
+References:
+    Turchin (2016), Ages of Discord, Chapter 10
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+from numpy.typing import NDArray
+
+if TYPE_CHECKING:
+    from cliodynamics.models.params import SDTParams
+
+
+@dataclass
+class Intervention(ABC):
+    """Base class for all policy interventions.
+
+    An intervention modifies the SDT system dynamics at specified times.
+    Subclasses implement specific intervention types (elite caps, wage
+    floors, etc.).
+
+    Attributes:
+        name: Human-readable name for the intervention.
+        start_time: Time at which intervention becomes active.
+        end_time: Time at which intervention ends. If None, runs forever.
+        description: Detailed description of the intervention.
+
+    Note:
+        Interventions are immutable after creation. To modify, create
+        a new intervention with updated parameters.
+    """
+
+    name: str
+    start_time: float
+    end_time: float | None = None
+    description: str = ""
+
+    def is_active(self, t: float) -> bool:
+        """Check if intervention is active at time t.
+
+        Args:
+            t: Current simulation time.
+
+        Returns:
+            True if start_time <= t < end_time (or forever if end_time is None).
+        """
+        if t < self.start_time:
+            return False
+        if self.end_time is not None and t >= self.end_time:
+            return False
+        return True
+
+    @abstractmethod
+    def modify_state(
+        self,
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """Modify the state vector during simulation.
+
+        This method is called at each time step to potentially modify
+        the state variables. The default implementation returns the
+        state unchanged.
+
+        Args:
+            state: Current state vector [N, E, W, S, psi].
+            t: Current time.
+            params: Model parameters.
+
+        Returns:
+            Modified state vector.
+        """
+        ...
+
+    @abstractmethod
+    def modify_derivatives(
+        self,
+        derivatives: NDArray[np.float64],
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """Modify the derivatives during simulation.
+
+        This method is called to modify dY/dt before integration.
+        Use this for interventions that change dynamics rather than
+        directly setting state values.
+
+        Args:
+            derivatives: Current derivatives [dN/dt, dE/dt, dW/dt, dS/dt, dpsi/dt].
+            state: Current state vector [N, E, W, S, psi].
+            t: Current time.
+            params: Model parameters.
+
+        Returns:
+            Modified derivatives.
+        """
+        ...
+
+
+# State variable indices for SDT model
+_N_IDX = 0
+_E_IDX = 1
+_W_IDX = 2
+_S_IDX = 3
+_PSI_IDX = 4
+
+
+@dataclass
+class EliteCap(Intervention):
+    """Cap elite population growth.
+
+    Limits the elite population to a maximum ratio of the baseline E_0.
+    This simulates policies that restrict entry into the elite class:
+    - Credential restrictions (limiting law degrees, PhDs)
+    - Wealth taxes that prevent accumulation
+    - Primogeniture or inheritance limits
+
+    Historical examples:
+    - Roman Lex Claudia restricting senatorial commerce
+    - Medieval guild restrictions
+    - Modern professional licensing
+
+    Attributes:
+        max_elite_ratio: Maximum E/E_0 ratio allowed.
+    """
+
+    max_elite_ratio: float = 1.5
+
+    def modify_state(
+        self,
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """Cap elite population at max_elite_ratio * E_0."""
+        if not self.is_active(t):
+            return state
+
+        modified = state.copy()
+        max_E = self.max_elite_ratio * params.E_0
+        if modified[_E_IDX] > max_E:
+            modified[_E_IDX] = max_E
+        return modified
+
+    def modify_derivatives(
+        self,
+        derivatives: NDArray[np.float64],
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """Prevent positive dE/dt when at cap."""
+        if not self.is_active(t):
+            return derivatives
+
+        modified = derivatives.copy()
+        max_E = self.max_elite_ratio * params.E_0
+
+        # If at or above cap and derivatives positive, zero out growth
+        if state[_E_IDX] >= max_E and modified[_E_IDX] > 0:
+            modified[_E_IDX] = 0.0
+
+        return modified
+
+
+@dataclass
+class ElitePurge(Intervention):
+    """Reduce elite population by a fraction.
+
+    Simulates events that reduce elite numbers:
+    - Civil wars eliminating rival factions
+    - Revolutions (French, Russian)
+    - Land reforms redistributing wealth
+
+    This is a discrete intervention: it reduces E once at start_time.
+
+    Attributes:
+        reduction_fraction: Fraction of elites removed (0.0 to 1.0).
+    """
+
+    reduction_fraction: float = 0.2
+
+    def __post_init__(self) -> None:
+        """Validate reduction fraction."""
+        if not 0 <= self.reduction_fraction <= 1:
+            raise ValueError("reduction_fraction must be between 0 and 1")
+        # Track if already applied
+        self._applied = False
+
+    def modify_state(
+        self,
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """Apply one-time reduction at start_time."""
+        if not self.is_active(t):
+            return state
+
+        # Only apply once
+        if self._applied:
+            return state
+
+        modified = state.copy()
+        modified[_E_IDX] *= 1 - self.reduction_fraction
+        self._applied = True
+        return modified
+
+    def modify_derivatives(
+        self,
+        derivatives: NDArray[np.float64],
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """No derivative modification for discrete intervention."""
+        return derivatives
+
+
+@dataclass
+class WageFloor(Intervention):
+    """Set a minimum wage level.
+
+    Prevents wages from falling below a specified fraction of baseline.
+    Simulates minimum wage laws, labor protections, or unionization.
+
+    Historical examples:
+    - Medieval guild wage standards
+    - New Deal labor reforms
+    - Modern minimum wage legislation
+
+    Attributes:
+        min_wage_ratio: Minimum W/W_0 ratio enforced.
+    """
+
+    min_wage_ratio: float = 0.8
+
+    def modify_state(
+        self,
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """Enforce wage floor."""
+        if not self.is_active(t):
+            return state
+
+        modified = state.copy()
+        min_W = self.min_wage_ratio * params.W_0
+        if modified[_W_IDX] < min_W:
+            modified[_W_IDX] = min_W
+        return modified
+
+    def modify_derivatives(
+        self,
+        derivatives: NDArray[np.float64],
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """Prevent negative dW/dt when at floor."""
+        if not self.is_active(t):
+            return derivatives
+
+        modified = derivatives.copy()
+        min_W = self.min_wage_ratio * params.W_0
+
+        # If at or below floor and derivatives negative, zero out decline
+        if state[_W_IDX] <= min_W and modified[_W_IDX] < 0:
+            modified[_W_IDX] = 0.0
+
+        return modified
+
+
+@dataclass
+class WageBoost(Intervention):
+    """Boost wage growth rate.
+
+    Increases wages by a specified percentage per year. Simulates
+    policies that raise worker bargaining power or productivity gains.
+
+    Historical examples:
+    - Post-WWII labor accords
+    - Productivity sharing agreements
+    - Immigration restrictions tightening labor markets
+
+    Attributes:
+        boost_rate: Additional annual growth rate (e.g., 0.02 for 2%/year).
+    """
+
+    boost_rate: float = 0.02
+
+    def modify_state(
+        self,
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """No direct state modification."""
+        return state
+
+    def modify_derivatives(
+        self,
+        derivatives: NDArray[np.float64],
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """Add boost to wage growth."""
+        if not self.is_active(t):
+            return derivatives
+
+        modified = derivatives.copy()
+        # Add boost_rate * W to dW/dt
+        modified[_W_IDX] += self.boost_rate * state[_W_IDX]
+        return modified
+
+
+@dataclass
+class TaxProgressivity(Intervention):
+    """Increase tax progressivity to redistribute from elites.
+
+    Increases state revenue while reducing elite growth.
+    Models progressive taxation that captures elite surplus
+    and funds public goods.
+
+    Historical examples:
+    - Roman tribute distributions
+    - Progressive income taxation (20th century)
+    - Estate/inheritance taxes
+
+    Attributes:
+        revenue_boost: Additional tax revenue rate (added to rho).
+        elite_drain: Additional reduction in elite growth (added to delta_e).
+    """
+
+    revenue_boost: float = 0.05
+    elite_drain: float = 0.01
+
+    def modify_state(
+        self,
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """No direct state modification."""
+        return state
+
+    def modify_derivatives(
+        self,
+        derivatives: NDArray[np.float64],
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """Boost state revenue, drain elite growth."""
+        if not self.is_active(t):
+            return derivatives
+
+        modified = derivatives.copy()
+        N, E, W, S, psi = state
+
+        # Additional revenue from progressive taxes
+        additional_revenue = self.revenue_boost * W * N
+        modified[_S_IDX] += additional_revenue
+
+        # Additional drain on elite (taxing their accumulation)
+        modified[_E_IDX] -= self.elite_drain * E
+
+        return modified
+
+
+@dataclass
+class FiscalAusterity(Intervention):
+    """Reduce state spending to improve fiscal health.
+
+    Reduces state expenditure rate, allowing faster recovery
+    of state fiscal health. May have negative effects on
+    legitimacy and popular welfare.
+
+    Historical examples:
+    - Diocletian's reforms
+    - Post-crisis austerity measures
+    - Debt reduction programs
+
+    Attributes:
+        spending_reduction: Fractional reduction in sigma (0.0 to 0.9).
+    """
+
+    spending_reduction: float = 0.2
+
+    def __post_init__(self) -> None:
+        """Validate spending reduction."""
+        if not 0 <= self.spending_reduction < 1:
+            raise ValueError("spending_reduction must be between 0 and 0.9")
+
+    def modify_state(
+        self,
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """No direct state modification."""
+        return state
+
+    def modify_derivatives(
+        self,
+        derivatives: NDArray[np.float64],
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """Reduce state expenditure."""
+        if not self.is_active(t):
+            return derivatives
+
+        modified = derivatives.copy()
+        S = state[_S_IDX]
+
+        # Reduce the negative expenditure term
+        expenditure_saved = self.spending_reduction * params.sigma * S
+        modified[_S_IDX] += expenditure_saved
+
+        return modified
+
+
+@dataclass
+class FiscalStimulus(Intervention):
+    """Increase state spending to boost wages and reduce instability.
+
+    Uses state resources to fund public works, welfare programs,
+    or redistribution that raises popular welfare.
+
+    Historical examples:
+    - Roman grain doles
+    - New Deal public works
+    - Modern stimulus programs
+
+    Attributes:
+        wage_boost: Boost to wage growth funded by state.
+        psi_reduction: Reduction in instability from social spending.
+        spending_rate: State resources consumed per year.
+    """
+
+    wage_boost: float = 0.02
+    psi_reduction: float = 0.01
+    spending_rate: float = 0.1
+
+    def modify_state(
+        self,
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """No direct state modification."""
+        return state
+
+    def modify_derivatives(
+        self,
+        derivatives: NDArray[np.float64],
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """Boost wages, reduce PSI, consume state resources."""
+        if not self.is_active(t):
+            return derivatives
+
+        modified = derivatives.copy()
+        W, S, psi = state[_W_IDX], state[_S_IDX], state[_PSI_IDX]
+
+        # Only spend if state has resources
+        if S > 0.1:
+            # Boost wages
+            modified[_W_IDX] += self.wage_boost * W
+            # Reduce instability
+            modified[_PSI_IDX] -= self.psi_reduction * psi
+            # Consume state resources
+            modified[_S_IDX] -= self.spending_rate * S
+
+        return modified
+
+
+@dataclass
+class MigrationControl(Intervention):
+    """Control population through migration policy.
+
+    Can either restrict population growth (emigration, lower immigration)
+    or boost it (open borders, pro-natalist policies).
+
+    Historical examples:
+    - Roman colonization (population export)
+    - Chinese one-child policy
+    - Immigration restrictions (1920s USA)
+
+    Attributes:
+        population_effect: Modifier to population growth rate.
+            Positive = encourage growth, negative = restrict growth.
+    """
+
+    population_effect: float = -0.01
+
+    def modify_state(
+        self,
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """No direct state modification."""
+        return state
+
+    def modify_derivatives(
+        self,
+        derivatives: NDArray[np.float64],
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """Modify population growth rate."""
+        if not self.is_active(t):
+            return derivatives
+
+        modified = derivatives.copy()
+        N = state[_N_IDX]
+
+        # Add/subtract from population growth
+        modified[_N_IDX] += self.population_effect * N
+
+        return modified
+
+
+@dataclass
+class FrontierExpansion(Intervention):
+    """Expand carrying capacity through territorial expansion.
+
+    Models acquiring new resources/territory that relieves
+    population pressure and provides elite opportunities.
+
+    Historical examples:
+    - Roman conquest (Republic period)
+    - American westward expansion
+    - Colonial expansion (European powers)
+
+    Attributes:
+        carrying_capacity_boost: Fractional increase in effective K.
+        elite_opportunity_boost: Additional elite outlets reducing competition.
+    """
+
+    carrying_capacity_boost: float = 0.1
+    elite_opportunity_boost: float = 0.01
+
+    def modify_state(
+        self,
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """No direct state modification."""
+        return state
+
+    def modify_derivatives(
+        self,
+        derivatives: NDArray[np.float64],
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """Boost population capacity and provide elite outlets."""
+        if not self.is_active(t):
+            return derivatives
+
+        modified = derivatives.copy()
+        N, E, W = state[_N_IDX], state[_E_IDX], state[_W_IDX]
+
+        # Effective carrying capacity boost reduces N/K ratio
+        # This allows more population growth when near capacity
+        # Approximated by adding to dN/dt when near K
+        capacity_factor = N / params.K_0
+        if capacity_factor > 0.7:
+            # More room to grow
+            capacity_relief = self.carrying_capacity_boost * params.r_max * N
+            modified[_N_IDX] += capacity_relief
+
+        # Elite opportunities in new territories reduce competition
+        # This reduces dE/dt slightly (elites emigrate to frontier)
+        modified[_E_IDX] -= self.elite_opportunity_boost * E
+
+        # Wages may rise due to labor scarcity in expansion
+        modified[_W_IDX] += 0.01 * W
+
+        return modified
+
+
+@dataclass
+class InstitutionalReform(Intervention):
+    """Reform institutions to improve governance and reduce instability.
+
+    Models political reforms that improve representation,
+    reduce corruption, or enhance state legitimacy.
+
+    Historical examples:
+    - Augustan reforms
+    - Constitutional reforms
+    - Democratization
+
+    Attributes:
+        legitimacy_boost: Reduction in instability accumulation.
+        efficiency_boost: Improvement in state revenue efficiency.
+        elite_restraint: Reduction in elite burden on state.
+    """
+
+    legitimacy_boost: float = 0.02
+    efficiency_boost: float = 0.02
+    elite_restraint: float = 0.01
+
+    def modify_state(
+        self,
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """No direct state modification."""
+        return state
+
+    def modify_derivatives(
+        self,
+        derivatives: NDArray[np.float64],
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """Improve governance outcomes."""
+        if not self.is_active(t):
+            return derivatives
+
+        modified = derivatives.copy()
+        N, E, W, S, psi = state
+
+        # Reduce instability accumulation
+        if modified[_PSI_IDX] > 0:
+            modified[_PSI_IDX] *= 1 - self.legitimacy_boost
+
+        # Improve state revenue
+        additional_revenue = self.efficiency_boost * params.rho * W * N
+        modified[_S_IDX] += additional_revenue
+
+        # Reduce elite burden on state
+        elite_burden_reduction = self.elite_restraint * params.epsilon * E
+        modified[_S_IDX] += elite_burden_reduction
+
+        return modified
+
+
+@dataclass
+class CompositeIntervention(Intervention):
+    """Combine multiple interventions into a policy package.
+
+    Allows testing comprehensive policy reforms that address
+    multiple SDT variables simultaneously.
+
+    Example:
+        >>> composite = CompositeIntervention(
+        ...     name="New Deal Package",
+        ...     start_time=1933,
+        ...     interventions=[
+        ...         WageFloor(name="Minimum wage", start_time=1933, min_wage_ratio=0.7),
+        ...         FiscalStimulus(
+        ...             name="Public works", start_time=1933, wage_boost=0.03
+        ...         ),
+        ...         TaxProgressivity(
+        ...             name="Progressive tax", start_time=1933,
+        ...             revenue_boost=0.1
+        ...         ),
+        ...     ]
+        ... )
+
+    Attributes:
+        interventions: List of interventions to apply.
+    """
+
+    interventions: list[Intervention] = field(default_factory=list)
+
+    def modify_state(
+        self,
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """Apply all constituent interventions' state modifications."""
+        if not self.is_active(t):
+            return state
+
+        modified = state.copy()
+        for intervention in self.interventions:
+            modified = intervention.modify_state(modified, t, params)
+        return modified
+
+    def modify_derivatives(
+        self,
+        derivatives: NDArray[np.float64],
+        state: NDArray[np.float64],
+        t: float,
+        params: "SDTParams",
+    ) -> NDArray[np.float64]:
+        """Apply all constituent interventions' derivative modifications."""
+        if not self.is_active(t):
+            return derivatives
+
+        modified = derivatives.copy()
+        for intervention in self.interventions:
+            modified = intervention.modify_derivatives(modified, state, t, params)
+        return modified
+
+
+# Factory functions for common intervention patterns
+
+
+def create_elite_management_policy(
+    start_time: float,
+    cap_ratio: float = 1.5,
+    purge_fraction: float = 0.0,
+    end_time: float | None = None,
+) -> Intervention:
+    """Create an elite management policy.
+
+    Args:
+        start_time: When policy begins.
+        cap_ratio: Maximum elite ratio (if > 1).
+        purge_fraction: Initial elite reduction (if > 0).
+        end_time: When policy ends.
+
+    Returns:
+        Intervention (single or composite).
+    """
+    interventions: list[Intervention] = []
+
+    if purge_fraction > 0:
+        interventions.append(
+            ElitePurge(
+                name="Elite purge",
+                start_time=start_time,
+                end_time=start_time + 1,  # One-time event
+                reduction_fraction=purge_fraction,
+            )
+        )
+
+    if cap_ratio > 0:
+        interventions.append(
+            EliteCap(
+                name="Elite cap",
+                start_time=start_time,
+                end_time=end_time,
+                max_elite_ratio=cap_ratio,
+            )
+        )
+
+    if len(interventions) == 1:
+        return interventions[0]
+    else:
+        return CompositeIntervention(
+            name="Elite management",
+            start_time=start_time,
+            end_time=end_time,
+            interventions=interventions,
+        )
+
+
+def create_welfare_policy(
+    start_time: float,
+    wage_floor: float = 0.8,
+    wage_boost: float = 0.01,
+    end_time: float | None = None,
+) -> Intervention:
+    """Create a popular welfare policy.
+
+    Args:
+        start_time: When policy begins.
+        wage_floor: Minimum wage ratio to baseline.
+        wage_boost: Additional wage growth rate.
+        end_time: When policy ends.
+
+    Returns:
+        Composite intervention.
+    """
+    return CompositeIntervention(
+        name="Welfare policy",
+        start_time=start_time,
+        end_time=end_time,
+        interventions=[
+            WageFloor(
+                name="Wage floor",
+                start_time=start_time,
+                end_time=end_time,
+                min_wage_ratio=wage_floor,
+            ),
+            WageBoost(
+                name="Wage boost",
+                start_time=start_time,
+                end_time=end_time,
+                boost_rate=wage_boost,
+            ),
+        ],
+    )
+
+
+__all__ = [
+    "Intervention",
+    "EliteCap",
+    "ElitePurge",
+    "WageFloor",
+    "WageBoost",
+    "TaxProgressivity",
+    "FiscalAusterity",
+    "FiscalStimulus",
+    "MigrationControl",
+    "FrontierExpansion",
+    "InstitutionalReform",
+    "CompositeIntervention",
+    "create_elite_management_policy",
+    "create_welfare_policy",
+]

--- a/tests/policy/__init__.py
+++ b/tests/policy/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the policy simulation framework."""

--- a/tests/policy/test_analysis.py
+++ b/tests/policy/test_analysis.py
@@ -1,0 +1,369 @@
+"""Tests for policy analysis tools.
+
+Tests cover:
+- OutcomeMetrics computation
+- OutcomeComparison between scenarios
+- SensitivityAnalysis across multiple interventions
+- PolicyRecommendation generation
+"""
+
+import pandas as pd
+import pytest
+
+from cliodynamics.policy.analysis import (
+    OutcomeComparison,
+    OutcomeMetrics,
+    PolicyRecommendation,
+    SensitivityAnalysis,
+    recommend_interventions,
+)
+from cliodynamics.policy.counterfactual import CounterfactualResult
+from cliodynamics.policy.interventions import EliteCap, TaxProgressivity, WageFloor
+from cliodynamics.simulation import SimulationResult
+
+
+def create_mock_result(
+    psi_values: list[float],
+    S_values: list[float] | None = None,
+    W_values: list[float] | None = None,
+    intervention=None,
+) -> CounterfactualResult:
+    """Create a mock CounterfactualResult for testing."""
+    n = len(psi_values)
+    t = list(range(n))
+
+    if S_values is None:
+        S_values = [1.0 - 0.3 * (i / (n - 1)) for i in range(n)]
+    if W_values is None:
+        W_values = [1.0 - 0.2 * (i / (n - 1)) for i in range(n)]
+
+    df = pd.DataFrame(
+        {
+            "t": t,
+            "N": [0.5 + 0.1 * (i / (n - 1)) for i in range(n)],
+            "E": [0.05 + 0.05 * (i / (n - 1)) for i in range(n)],
+            "W": W_values,
+            "S": S_values,
+            "psi": psi_values,
+        }
+    )
+
+    sim_result = SimulationResult(df=df, events=[], terminated_by_event=False)
+
+    return CounterfactualResult(
+        result=sim_result,
+        intervention=intervention,
+    )
+
+
+class TestOutcomeMetrics:
+    """Tests for OutcomeMetrics computation."""
+
+    def test_psi_metrics(self):
+        """PSI metrics computed correctly."""
+        # PSI peaks at index 6 (value 0.6), then declines
+        psi_values = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.5, 0.4, 0.3]
+        result = create_mock_result(psi_values)
+
+        metrics = OutcomeMetrics.from_result(result)
+
+        assert metrics.psi_peak == pytest.approx(0.6)
+        assert metrics.psi_peak_time == pytest.approx(6)
+        assert metrics.psi_final == pytest.approx(0.3)
+
+    def test_psi_integral(self):
+        """PSI integral computed using trapezoidal rule."""
+        psi_values = [0.0, 0.2, 0.4, 0.2, 0.0]  # Triangle-like
+        result = create_mock_result(psi_values)
+
+        metrics = OutcomeMetrics.from_result(result)
+
+        # Trapezoidal integral for [0,0.2,0.4,0.2,0] over t=[0,1,2,3,4]
+        # = 0.5*(0+0.2) + 0.5*(0.2+0.4) + 0.5*(0.4+0.2) + 0.5*(0.2+0)
+        # = 0.1 + 0.3 + 0.3 + 0.1 = 0.8
+        assert metrics.psi_integral == pytest.approx(0.8)
+
+    def test_collapse_detection(self):
+        """Collapse detected when S < 0.1."""
+        # S drops below 0.1 at t=7
+        S_values = [1.0, 0.8, 0.6, 0.4, 0.3, 0.2, 0.15, 0.08, 0.05, 0.05]
+        result = create_mock_result([0.0] * 10, S_values=S_values)
+
+        metrics = OutcomeMetrics.from_result(result)
+
+        assert metrics.collapse_time == pytest.approx(7)
+
+    def test_no_collapse(self):
+        """No collapse when S stays above 0.1."""
+        S_values = [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.15]
+        result = create_mock_result([0.0] * 10, S_values=S_values)
+
+        metrics = OutcomeMetrics.from_result(result)
+
+        assert metrics.collapse_time is None
+
+    def test_recovery_time(self):
+        """Recovery time computed from peak to PSI < 0.1."""
+        # PSI peaks at t=5, drops below 0.1 at t=8
+        psi_values = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.3, 0.15, 0.05, 0.02]
+        result = create_mock_result(psi_values)
+
+        metrics = OutcomeMetrics.from_result(result)
+
+        assert metrics.psi_peak_time == pytest.approx(5)
+        assert metrics.recovery_time == pytest.approx(3)  # 8 - 5
+
+    def test_wage_and_state_minima(self):
+        """Minimum wage and state values tracked."""
+        W_values = [1.0, 0.9, 0.8, 0.6, 0.5, 0.55, 0.6, 0.7, 0.8, 0.85]
+        S_values = [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.45, 0.5, 0.6, 0.7]
+        result = create_mock_result([0.0] * 10, S_values=S_values, W_values=W_values)
+
+        metrics = OutcomeMetrics.from_result(result)
+
+        assert metrics.wage_minimum == pytest.approx(0.5)
+        assert metrics.state_minimum == pytest.approx(0.45)
+
+
+class TestOutcomeComparison:
+    """Tests for OutcomeComparison."""
+
+    @pytest.fixture
+    def baseline(self):
+        """Baseline with moderate crisis."""
+        psi_values = [0.0, 0.1, 0.2, 0.4, 0.6, 0.8, 0.7, 0.5, 0.3, 0.2]
+        return create_mock_result(psi_values)
+
+    @pytest.fixture
+    def intervention(self):
+        """Intervention that reduces crisis."""
+        psi_values = [0.0, 0.1, 0.15, 0.25, 0.35, 0.4, 0.35, 0.25, 0.15, 0.1]
+        cap = EliteCap(name="Elite cap", start_time=20)
+        return create_mock_result(psi_values, intervention=cap)
+
+    def test_psi_peak_reduction(self, baseline, intervention):
+        """PSI peak reduction computed correctly."""
+        comparison = OutcomeComparison(baseline, intervention)
+
+        # Baseline peak = 0.8, intervention peak = 0.4
+        # Reduction = (0.8 - 0.4) / 0.8 = 0.5
+        assert comparison.psi_peak_reduction() == pytest.approx(0.5)
+
+    def test_psi_peak_delay(self, baseline, intervention):
+        """PSI peak delay computed correctly."""
+        comparison = OutcomeComparison(baseline, intervention)
+
+        # Baseline peak at t=5, intervention peak at t=5
+        # (They happen to peak at same time in this example)
+        assert comparison.psi_peak_delay() == pytest.approx(0)
+
+    def test_collapse_prevented(self):
+        """Collapse prevention detected."""
+        # Baseline collapses (S < 0.1)
+        baseline = create_mock_result(
+            [0.0] * 10, S_values=[1.0, 0.8, 0.6, 0.4, 0.2, 0.1, 0.08, 0.05, 0.05, 0.05]
+        )
+
+        # Intervention prevents collapse
+        intervention_result = create_mock_result(
+            [0.0] * 10,
+            S_values=[1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.45, 0.5, 0.55, 0.6],
+            intervention=EliteCap(name="Cap", start_time=0),
+        )
+
+        comparison = OutcomeComparison(baseline, intervention_result)
+        assert comparison.collapse_prevented()
+
+    def test_wage_improvement(self, baseline, intervention):
+        """Wage improvement computed correctly."""
+        comparison = OutcomeComparison(baseline, intervention)
+
+        # Both have same W trajectory in this mock, so improvement = 0
+        assert comparison.wage_improvement() == pytest.approx(0)
+
+    def test_trajectory_difference(self, baseline, intervention):
+        """Trajectory difference DataFrame created correctly."""
+        comparison = OutcomeComparison(baseline, intervention)
+
+        diff_df = comparison.trajectory_difference("psi")
+
+        assert "t" in diff_df.columns
+        assert "baseline" in diff_df.columns
+        assert "intervention" in diff_df.columns
+        assert "difference" in diff_df.columns
+
+    def test_summary(self, baseline, intervention):
+        """Summary string generated."""
+        comparison = OutcomeComparison(baseline, intervention)
+        summary = comparison.summary()
+
+        assert "Outcome Comparison" in summary
+        assert "Peak reduction" in summary
+
+
+class TestSensitivityAnalysis:
+    """Tests for SensitivityAnalysis."""
+
+    @pytest.fixture
+    def baseline(self):
+        psi_values = [0.0, 0.1, 0.2, 0.4, 0.6, 0.8, 0.7, 0.5, 0.3, 0.2]
+        return create_mock_result(psi_values)
+
+    @pytest.fixture
+    def results(self):
+        """Multiple intervention results with different effectiveness."""
+        return [
+            create_mock_result(
+                [0.0, 0.1, 0.15, 0.25, 0.35, 0.4, 0.35, 0.25, 0.15, 0.1],
+                intervention=EliteCap(
+                    name="Strong cap", start_time=0, max_elite_ratio=1.0
+                ),
+            ),
+            create_mock_result(
+                [0.0, 0.1, 0.18, 0.32, 0.48, 0.6, 0.55, 0.42, 0.28, 0.18],
+                intervention=EliteCap(
+                    name="Weak cap", start_time=0, max_elite_ratio=1.5
+                ),
+            ),
+            create_mock_result(
+                [0.0, 0.1, 0.17, 0.3, 0.45, 0.55, 0.5, 0.38, 0.25, 0.15],
+                intervention=WageFloor(
+                    name="Wage floor", start_time=0, min_wage_ratio=0.8
+                ),
+            ),
+        ]
+
+    def test_rank_by_psi_reduction(self, baseline, results):
+        """Interventions ranked by PSI peak reduction."""
+        analysis = SensitivityAnalysis(baseline, results)
+        ranked = analysis.rank_by_psi_reduction()
+
+        assert len(ranked) == 3
+        # Strong cap (0.4 peak) should be first (best reduction)
+        assert ranked[0][0] == "Strong cap"
+        assert ranked[0][1] == pytest.approx(0.5)  # (0.8 - 0.4) / 0.8
+
+    def test_rank_by_integral_reduction(self, baseline, results):
+        """Interventions ranked by cumulative instability reduction."""
+        analysis = SensitivityAnalysis(baseline, results)
+        ranked = analysis.rank_by_integral_reduction()
+
+        assert len(ranked) == 3
+
+    def test_to_dataframe(self, baseline, results):
+        """Analysis converts to DataFrame."""
+        analysis = SensitivityAnalysis(baseline, results)
+        df = analysis.to_dataframe()
+
+        assert len(df) == 3
+        assert "intervention" in df.columns
+        assert "psi_peak_reduction" in df.columns
+        assert "collapse_prevented" in df.columns
+
+    def test_summary(self, baseline, results):
+        """Summary string generated."""
+        analysis = SensitivityAnalysis(baseline, results)
+        summary = analysis.summary()
+
+        assert "Sensitivity Analysis" in summary
+        assert "Ranked by PSI Peak Reduction" in summary
+
+
+class TestPolicyRecommendation:
+    """Tests for PolicyRecommendation."""
+
+    def test_summary(self):
+        """Recommendation summary generated."""
+        intervention = EliteCap(name="Elite cap", start_time=50)
+        rec = PolicyRecommendation(
+            intervention=intervention,
+            effectiveness=0.3,
+            timing=50.0,
+            confidence=0.8,
+            rationale="Limits elite overproduction.",
+            trade_offs=["May reduce innovation"],
+            historical_precedents=["Roman Lex Claudia"],
+        )
+
+        summary = rec.summary()
+
+        assert "Elite cap" in summary
+        assert "30" in summary  # Matches 30%, 30.0%, or 0.30
+        assert "Rationale" in summary
+        assert "Trade-offs" in summary
+        assert "Historical precedents" in summary
+
+
+class TestRecommendInterventions:
+    """Tests for recommend_interventions function."""
+
+    @pytest.fixture
+    def baseline(self):
+        psi_values = [0.0, 0.1, 0.2, 0.4, 0.6, 0.8, 0.7, 0.5, 0.3, 0.2]
+        return create_mock_result(psi_values)
+
+    @pytest.fixture
+    def results(self):
+        return [
+            create_mock_result(
+                [0.0, 0.1, 0.15, 0.25, 0.35, 0.4, 0.35, 0.25, 0.15, 0.1],
+                intervention=EliteCap(name="Elite cap", start_time=0),
+            ),
+            create_mock_result(
+                [0.0, 0.1, 0.18, 0.32, 0.48, 0.55, 0.5, 0.38, 0.25, 0.15],
+                intervention=WageFloor(name="Wage floor", start_time=0),
+            ),
+            create_mock_result(
+                [0.0, 0.1, 0.16, 0.28, 0.42, 0.5, 0.45, 0.35, 0.22, 0.12],
+                intervention=TaxProgressivity(name="Tax reform", start_time=0),
+            ),
+        ]
+
+    def test_minimize_psi_peak(self, baseline, results):
+        """Recommendations for minimizing PSI peak."""
+        recs = recommend_interventions(
+            baseline=baseline,
+            intervention_results=results,
+            objective="minimize_psi_peak",
+            max_recommendations=3,
+        )
+
+        assert len(recs) <= 3
+        # Best should be elite cap (peak 0.4 vs baseline 0.8)
+        assert recs[0].intervention.name == "Elite cap"
+
+    def test_minimize_psi_integral(self, baseline, results):
+        """Recommendations for minimizing cumulative instability."""
+        recs = recommend_interventions(
+            baseline=baseline,
+            intervention_results=results,
+            objective="minimize_psi_integral",
+            max_recommendations=3,
+        )
+
+        assert len(recs) <= 3
+
+    def test_with_constraints(self, baseline, results):
+        """Constraints filter out ineligible interventions."""
+        # Add a politically radical intervention
+        from cliodynamics.policy.interventions import ElitePurge
+
+        radical_result = create_mock_result(
+            [0.0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.2, 0.15, 0.1, 0.05],
+            intervention=ElitePurge(
+                name="Elite purge", start_time=0, reduction_fraction=0.3
+            ),
+        )
+        results.append(radical_result)
+
+        recs = recommend_interventions(
+            baseline=baseline,
+            intervention_results=results,
+            objective="minimize_psi_peak",
+            constraints=["politically_feasible"],
+            max_recommendations=5,
+        )
+
+        # Purge should be filtered out
+        intervention_names = [r.intervention.name for r in recs]
+        assert "Elite purge" not in intervention_names

--- a/tests/policy/test_counterfactual.py
+++ b/tests/policy/test_counterfactual.py
@@ -1,0 +1,332 @@
+"""Tests for counterfactual simulation engine.
+
+Tests cover:
+- Baseline simulation
+- Intervention application
+- InterventionModel wrapper
+- Batch intervention testing
+- Intervention timing analysis
+
+Note: The SDT model with default parameters can exhibit exponentially growing
+dynamics (particularly for wages W). Tests use parameters tuned for more
+stable dynamics.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from cliodynamics.models import SDTModel
+from cliodynamics.models.params import SDTParams
+from cliodynamics.policy.counterfactual import (
+    CounterfactualEngine,
+    CounterfactualResult,
+    InterventionModel,
+)
+from cliodynamics.policy.interventions import (
+    EliteCap,
+    WageBoost,
+    WageFloor,
+)
+
+
+def stable_params() -> SDTParams:
+    """Return parameters tuned for stable, bounded dynamics.
+
+    These parameters reduce the wage sensitivity coefficients to prevent
+    exponential wage growth that can make simulations computationally expensive.
+    """
+    return SDTParams(
+        r_max=0.02,
+        K_0=1.0,
+        beta=1.0,
+        mu=0.2,
+        alpha=0.005,
+        delta_e=0.02,
+        gamma=0.01,  # Very small for stable tests (default is 2.0)
+        eta=0.01,  # Very small for stable tests (default is 1.0)
+        rho=0.2,
+        sigma=0.1,
+        epsilon=0.05,
+        lambda_psi=0.05,
+        theta_w=1.0,
+        theta_e=1.0,
+        theta_s=1.0,
+        psi_decay=0.02,
+        W_0=1.0,
+        E_0=0.1,
+        S_0=1.0,
+    )
+
+
+class TestInterventionModel:
+    """Tests for InterventionModel wrapper."""
+
+    @pytest.fixture
+    def base_model(self):
+        return SDTModel(stable_params())
+
+    @pytest.fixture
+    def intervention(self):
+        return EliteCap(name="Cap", start_time=0, max_elite_ratio=1.5)
+
+    def test_wraps_base_model(self, base_model, intervention):
+        """InterventionModel exposes base model params."""
+        model = InterventionModel(base_model, [intervention])
+        assert model.params == base_model.params
+
+    def test_applies_intervention(self, base_model, intervention):
+        """InterventionModel applies intervention during system()."""
+        model = InterventionModel(base_model, [intervention])
+
+        # State with elite above cap
+        state = np.array([0.5, 0.2, 1.0, 1.0, 0.1])
+
+        # Base model would have positive dE/dt
+        base_derivs = base_model.system(state, 10)
+
+        # Intervention model should cap dE/dt if at limit
+        # First apply state modification, which caps E at 0.15
+        # Then derivatives should be computed from capped state
+        derivs = model.system(state, 10)
+
+        # The derivatives should differ due to intervention
+        assert not np.allclose(derivs, base_derivs)
+
+
+class TestCounterfactualEngine:
+    """Tests for CounterfactualEngine."""
+
+    @pytest.fixture
+    def model(self):
+        return SDTModel(stable_params())
+
+    @pytest.fixture
+    def engine(self, model):
+        return CounterfactualEngine(model)
+
+    @pytest.fixture
+    def initial_conditions(self):
+        return {"N": 0.5, "E": 0.05, "W": 1.0, "S": 1.0, "psi": 0.0}
+
+    def test_run_baseline(self, engine, initial_conditions):
+        """Baseline simulation runs without intervention."""
+        result = engine.run_baseline(
+            initial_conditions=initial_conditions,
+            time_span=(0, 100),
+            dt=1.0,
+        )
+
+        assert isinstance(result, CounterfactualResult)
+        assert result.is_baseline
+        assert result.intervention is None
+        assert len(result.df) > 0
+        assert "t" in result.df.columns
+        assert "psi" in result.df.columns
+
+    def test_baseline_metadata(self, engine, initial_conditions):
+        """Baseline stores correct metadata."""
+        result = engine.run_baseline(
+            initial_conditions=initial_conditions,
+            time_span=(0, 100),
+            dt=1.0,
+        )
+
+        assert result.metadata["time_span"] == (0, 100)
+        assert result.metadata["dt"] == 1.0
+        assert result.metadata["initial_conditions"] == initial_conditions
+
+    def test_run_intervention(self, engine, initial_conditions):
+        """Intervention simulation applies the intervention."""
+        baseline = engine.run_baseline(
+            initial_conditions=initial_conditions,
+            time_span=(0, 100),
+            dt=1.0,
+        )
+
+        intervention = EliteCap(
+            name="Elite cap",
+            start_time=50,
+            max_elite_ratio=1.2,
+        )
+
+        result = engine.run_intervention(baseline, intervention)
+
+        assert not result.is_baseline
+        assert result.intervention == intervention
+        assert result.baseline_reference == baseline
+
+    def test_intervention_changes_trajectory(self, engine, initial_conditions):
+        """Intervention modifies the trajectory.
+
+        Tests that a WageBoost intervention produces different wage outcomes
+        than the baseline. This is a more direct test since WageBoost always
+        adds to dW/dt when active.
+        """
+        baseline = engine.run_baseline(
+            initial_conditions=initial_conditions,
+            time_span=(0, 100),
+            dt=1.0,
+        )
+
+        # Use WageBoost which always increases wages when active
+        intervention = WageBoost(
+            name="Wage boost",
+            start_time=10,
+            boost_rate=0.05,  # 5% annual boost
+        )
+
+        result = engine.run_intervention(baseline, intervention)
+
+        # Compare wage trajectories at end
+        baseline_W_final = baseline.df["W"].iloc[-1]
+        intervention_W_final = result.df["W"].iloc[-1]
+
+        # Intervention should boost wages above baseline
+        assert intervention_W_final > baseline_W_final
+
+    def test_run_interventions_batch(self, engine, initial_conditions):
+        """Batch intervention testing runs multiple scenarios."""
+        baseline = engine.run_baseline(
+            initial_conditions=initial_conditions,
+            time_span=(0, 100),
+            dt=1.0,
+        )
+
+        interventions = [
+            EliteCap(name="Cap 1.2", start_time=50, max_elite_ratio=1.2),
+            EliteCap(name="Cap 1.5", start_time=50, max_elite_ratio=1.5),
+            WageFloor(name="Wage 0.8", start_time=50, min_wage_ratio=0.8),
+        ]
+
+        results = engine.run_interventions(baseline, interventions)
+
+        assert len(results) == 3
+        for result in results:
+            assert isinstance(result, CounterfactualResult)
+
+    def test_run_from_state(self, engine):
+        """run_from_state starts from arbitrary state."""
+        state = {"N": 0.7, "E": 0.15, "W": 0.8, "S": 0.9, "psi": 0.3}
+
+        result = engine.run_from_state(
+            state=state,
+            time_span=(50, 150),
+            dt=1.0,
+        )
+
+        # Should start near the specified state
+        first_row = result.df.iloc[0]
+        assert first_row["t"] == pytest.approx(50)
+        assert first_row["N"] == pytest.approx(0.7)
+        assert first_row["psi"] == pytest.approx(0.3)
+
+    def test_run_from_state_with_intervention(self, engine):
+        """run_from_state applies intervention."""
+        state = {"N": 0.7, "E": 0.15, "W": 0.8, "S": 0.9, "psi": 0.3}
+
+        intervention = EliteCap(name="Cap", start_time=50, max_elite_ratio=1.0)
+
+        result = engine.run_from_state(
+            state=state,
+            time_span=(50, 150),
+            intervention=intervention,
+            dt=1.0,
+        )
+
+        assert result.intervention == intervention
+
+
+class TestCounterfactualResult:
+    """Tests for CounterfactualResult properties."""
+
+    @pytest.fixture
+    def sample_result(self):
+        """Create a sample result for testing."""
+        df = pd.DataFrame(
+            {
+                "t": [0, 10, 20, 30, 40, 50],
+                "N": [0.5, 0.55, 0.6, 0.65, 0.7, 0.72],
+                "E": [0.05, 0.06, 0.08, 0.1, 0.12, 0.14],
+                "W": [1.0, 0.95, 0.9, 0.85, 0.8, 0.78],
+                "S": [1.0, 0.95, 0.9, 0.85, 0.7, 0.6],
+                "psi": [0.0, 0.05, 0.15, 0.3, 0.4, 0.35],
+            }
+        )
+
+        from cliodynamics.simulation import SimulationResult
+
+        sim_result = SimulationResult(df=df, events=[], terminated_by_event=False)
+
+        return CounterfactualResult(
+            result=sim_result,
+            intervention=None,
+        )
+
+    def test_psi_peak(self, sample_result):
+        """psi_peak returns maximum PSI."""
+        assert sample_result.psi_peak == pytest.approx(0.4)
+
+    def test_psi_peak_time(self, sample_result):
+        """psi_peak_time returns time of maximum PSI."""
+        assert sample_result.psi_peak_time == pytest.approx(40)
+
+    def test_final_state(self, sample_result):
+        """final_state returns last row values."""
+        final = sample_result.final_state
+        assert final["psi"] == pytest.approx(0.35)
+        assert final["N"] == pytest.approx(0.72)
+
+    def test_state_at_time(self, sample_result):
+        """state_at_time interpolates correctly."""
+        # Exact time point
+        state = sample_result.state_at_time(20)
+        assert state["psi"] == pytest.approx(0.15)
+
+        # Interpolated time point
+        state = sample_result.state_at_time(15)
+        assert state["psi"] == pytest.approx(0.1)  # Midpoint
+
+    def test_is_baseline(self, sample_result):
+        """is_baseline correctly identifies baseline."""
+        assert sample_result.is_baseline
+
+        # Add an intervention
+        sample_result.intervention = EliteCap(name="test", start_time=0)
+        assert not sample_result.is_baseline
+
+
+class TestInterventionTiming:
+    """Tests for finding optimal intervention timing."""
+
+    @pytest.fixture
+    def model(self):
+        return SDTModel(stable_params())
+
+    @pytest.fixture
+    def engine(self, model):
+        return CounterfactualEngine(model)
+
+    def test_find_intervention_timing(self, engine):
+        """find_intervention_timing tests multiple start times."""
+        initial = {"N": 0.5, "E": 0.05, "W": 1.0, "S": 1.0, "psi": 0.0}
+        baseline = engine.run_baseline(
+            initial_conditions=initial,
+            time_span=(0, 100),
+            dt=1.0,
+        )
+
+        def intervention_factory(t):
+            return EliteCap(name=f"Cap at {t}", start_time=t, max_elite_ratio=1.2)
+
+        results = engine.find_intervention_timing(
+            baseline=baseline,
+            intervention_factory=intervention_factory,
+            start_times=[10, 30, 50, 70],
+            metric="psi_peak",
+        )
+
+        assert len(results) == 4
+        for t, (value, result) in results.items():
+            assert isinstance(value, float)
+            assert isinstance(result, CounterfactualResult)

--- a/tests/policy/test_interventions.py
+++ b/tests/policy/test_interventions.py
@@ -1,0 +1,426 @@
+"""Tests for policy interventions.
+
+Tests cover:
+- Intervention activation logic
+- State modification by each intervention type
+- Derivative modification by each intervention type
+- Composite interventions
+"""
+
+import numpy as np
+import pytest
+
+from cliodynamics.models.params import SDTParams
+from cliodynamics.policy.interventions import (
+    CompositeIntervention,
+    EliteCap,
+    ElitePurge,
+    FiscalAusterity,
+    FiscalStimulus,
+    FrontierExpansion,
+    InstitutionalReform,
+    MigrationControl,
+    TaxProgressivity,
+    WageBoost,
+    WageFloor,
+    create_elite_management_policy,
+    create_welfare_policy,
+)
+
+
+class TestInterventionActivation:
+    """Tests for intervention is_active() logic."""
+
+    def test_before_start(self):
+        """Intervention inactive before start_time."""
+        intervention = EliteCap(name="test", start_time=50)
+        assert not intervention.is_active(0)
+        assert not intervention.is_active(49)
+
+    def test_at_start(self):
+        """Intervention active at start_time."""
+        intervention = EliteCap(name="test", start_time=50)
+        assert intervention.is_active(50)
+
+    def test_after_start(self):
+        """Intervention active after start_time."""
+        intervention = EliteCap(name="test", start_time=50)
+        assert intervention.is_active(100)
+        assert intervention.is_active(1000)
+
+    def test_with_end_time(self):
+        """Intervention inactive after end_time."""
+        intervention = EliteCap(name="test", start_time=50, end_time=100)
+        assert intervention.is_active(50)
+        assert intervention.is_active(99)
+        assert not intervention.is_active(100)
+        assert not intervention.is_active(200)
+
+
+class TestEliteCap:
+    """Tests for EliteCap intervention."""
+
+    @pytest.fixture
+    def params(self):
+        return SDTParams(E_0=0.1)
+
+    @pytest.fixture
+    def intervention(self):
+        return EliteCap(
+            name="Elite cap",
+            start_time=0,
+            max_elite_ratio=1.5,
+        )
+
+    def test_cap_not_exceeded(self, intervention, params):
+        """State unchanged when elite below cap."""
+        state = np.array([0.5, 0.1, 1.0, 1.0, 0.1])  # E = 0.1 = E_0
+        modified = intervention.modify_state(state, t=10, params=params)
+        assert modified[1] == 0.1
+
+    def test_cap_exceeded(self, intervention, params):
+        """Elite capped when above maximum."""
+        state = np.array([0.5, 0.2, 1.0, 1.0, 0.1])  # E = 0.2 = 2*E_0 > 1.5*E_0
+        modified = intervention.modify_state(state, t=10, params=params)
+        assert modified[1] == pytest.approx(0.15)  # 1.5 * E_0
+
+    def test_derivative_capped(self, intervention, params):
+        """Positive dE/dt zeroed when at or above cap."""
+        # Use value clearly above cap (0.16 > 0.15) to avoid floating-point issues
+        state = np.array([0.5, 0.16, 1.0, 1.0, 0.1])  # Above cap
+        derivatives = np.array([0.01, 0.01, 0.0, 0.0, 0.01])  # dE/dt positive
+        modified = intervention.modify_derivatives(
+            derivatives, state, t=10, params=params
+        )
+        assert modified[1] == 0.0  # dE/dt zeroed
+
+    def test_derivative_not_capped_below_cap(self, intervention, params):
+        """dE/dt unchanged when below cap."""
+        state = np.array([0.5, 0.1, 1.0, 1.0, 0.1])  # Below cap
+        derivatives = np.array([0.01, 0.01, 0.0, 0.0, 0.01])
+        modified = intervention.modify_derivatives(
+            derivatives, state, t=10, params=params
+        )
+        assert modified[1] == 0.01  # Unchanged
+
+    def test_inactive_when_before_start(self, params):
+        """Intervention has no effect before start_time."""
+        intervention = EliteCap(name="test", start_time=50, max_elite_ratio=1.5)
+        state = np.array([0.5, 0.2, 1.0, 1.0, 0.1])  # Above cap
+        modified = intervention.modify_state(state, t=10, params=params)
+        assert modified[1] == 0.2  # Unchanged
+
+
+class TestElitePurge:
+    """Tests for ElitePurge intervention."""
+
+    @pytest.fixture
+    def params(self):
+        return SDTParams(E_0=0.1)
+
+    def test_one_time_reduction(self, params):
+        """Elite reduced once at start_time."""
+        intervention = ElitePurge(
+            name="Purge",
+            start_time=50,
+            reduction_fraction=0.2,
+        )
+        state = np.array([0.5, 0.1, 1.0, 1.0, 0.1])
+
+        # First application
+        modified = intervention.modify_state(state, t=50, params=params)
+        assert modified[1] == pytest.approx(0.08)
+
+        # Second application - should not reduce again
+        modified2 = intervention.modify_state(modified, t=51, params=params)
+        assert modified2[1] == pytest.approx(0.08)
+
+    def test_invalid_fraction(self):
+        """Reject invalid reduction_fraction values."""
+        with pytest.raises(ValueError):
+            ElitePurge(name="test", start_time=0, reduction_fraction=1.5)
+        with pytest.raises(ValueError):
+            ElitePurge(name="test", start_time=0, reduction_fraction=-0.1)
+
+
+class TestWageFloor:
+    """Tests for WageFloor intervention."""
+
+    @pytest.fixture
+    def params(self):
+        return SDTParams(W_0=1.0)
+
+    @pytest.fixture
+    def intervention(self):
+        return WageFloor(
+            name="Wage floor",
+            start_time=0,
+            min_wage_ratio=0.8,
+        )
+
+    def test_floor_not_reached(self, intervention, params):
+        """Wages unchanged when above floor."""
+        state = np.array([0.5, 0.1, 1.0, 1.0, 0.1])  # W = 1.0 > 0.8
+        modified = intervention.modify_state(state, t=10, params=params)
+        assert modified[2] == 1.0
+
+    def test_floor_enforced(self, intervention, params):
+        """Wages raised to floor when below."""
+        state = np.array([0.5, 0.1, 0.5, 1.0, 0.1])  # W = 0.5 < 0.8
+        modified = intervention.modify_state(state, t=10, params=params)
+        assert modified[2] == pytest.approx(0.8)
+
+    def test_derivative_floor(self, intervention, params):
+        """Negative dW/dt zeroed at or below floor."""
+        # Use value clearly below floor to avoid floating-point issues
+        state = np.array([0.5, 0.1, 0.79, 1.0, 0.1])  # Below floor
+        derivatives = np.array([0.01, 0.01, -0.05, 0.0, 0.01])  # dW/dt negative
+        modified = intervention.modify_derivatives(
+            derivatives, state, t=10, params=params
+        )
+        assert modified[2] == 0.0
+
+
+class TestWageBoost:
+    """Tests for WageBoost intervention."""
+
+    @pytest.fixture
+    def params(self):
+        return SDTParams(W_0=1.0)
+
+    def test_boost_rate_applied(self, params):
+        """Wage growth boosted by specified rate."""
+        intervention = WageBoost(
+            name="Boost",
+            start_time=0,
+            boost_rate=0.02,
+        )
+        state = np.array([0.5, 0.1, 1.0, 1.0, 0.1])
+        derivatives = np.array([0.01, 0.01, 0.0, 0.0, 0.01])
+
+        modified = intervention.modify_derivatives(
+            derivatives, state, t=10, params=params
+        )
+        assert modified[2] == pytest.approx(0.02)  # 0.02 * 1.0
+
+
+class TestTaxProgressivity:
+    """Tests for TaxProgressivity intervention."""
+
+    @pytest.fixture
+    def params(self):
+        return SDTParams(rho=0.2)
+
+    def test_revenue_boost(self, params):
+        """State revenue increased."""
+        intervention = TaxProgressivity(
+            name="Tax",
+            start_time=0,
+            revenue_boost=0.05,
+            elite_drain=0.01,
+        )
+        state = np.array([0.5, 0.1, 1.0, 1.0, 0.1])  # N=0.5, E=0.1, W=1.0
+        derivatives = np.array([0.01, 0.01, 0.0, 0.0, 0.01])
+
+        modified = intervention.modify_derivatives(
+            derivatives, state, t=10, params=params
+        )
+
+        # Revenue boost: 0.05 * W * N = 0.05 * 1.0 * 0.5 = 0.025
+        assert modified[3] == pytest.approx(0.025)
+        # Elite drain: 0.01 * E = 0.01 * 0.1 = 0.001
+        assert modified[1] == pytest.approx(0.01 - 0.001)
+
+
+class TestFiscalAusterity:
+    """Tests for FiscalAusterity intervention."""
+
+    @pytest.fixture
+    def params(self):
+        return SDTParams(sigma=0.1)
+
+    def test_spending_reduction(self, params):
+        """State spending reduced."""
+        intervention = FiscalAusterity(
+            name="Austerity",
+            start_time=0,
+            spending_reduction=0.2,
+        )
+        state = np.array([0.5, 0.1, 1.0, 1.0, 0.1])  # S = 1.0
+        derivatives = np.array([0.01, 0.01, 0.0, 0.0, 0.01])
+
+        modified = intervention.modify_derivatives(
+            derivatives, state, t=10, params=params
+        )
+
+        # Expenditure saved: 0.2 * 0.1 * 1.0 = 0.02
+        assert modified[3] == pytest.approx(0.02)
+
+
+class TestFiscalStimulus:
+    """Tests for FiscalStimulus intervention."""
+
+    @pytest.fixture
+    def params(self):
+        return SDTParams()
+
+    def test_stimulus_effects(self, params):
+        """Stimulus boosts wages, reduces PSI, spends state resources."""
+        intervention = FiscalStimulus(
+            name="Stimulus",
+            start_time=0,
+            wage_boost=0.02,
+            psi_reduction=0.01,
+            spending_rate=0.1,
+        )
+        state = np.array([0.5, 0.1, 1.0, 1.0, 0.5])  # S=1.0, psi=0.5
+        derivatives = np.array([0.01, 0.01, 0.0, 0.0, 0.01])
+
+        modified = intervention.modify_derivatives(
+            derivatives, state, t=10, params=params
+        )
+
+        # Wage boost: 0.02 * W = 0.02
+        assert modified[2] == pytest.approx(0.02)
+        # PSI reduction: -0.01 * psi = -0.005
+        assert modified[4] == pytest.approx(0.01 - 0.005)
+        # Spending: -0.1 * S = -0.1
+        assert modified[3] == pytest.approx(-0.1)
+
+
+class TestMigrationControl:
+    """Tests for MigrationControl intervention."""
+
+    @pytest.fixture
+    def params(self):
+        return SDTParams()
+
+    def test_population_reduction(self, params):
+        """Negative effect reduces population growth."""
+        intervention = MigrationControl(
+            name="Emigration",
+            start_time=0,
+            population_effect=-0.01,
+        )
+        state = np.array([0.5, 0.1, 1.0, 1.0, 0.1])
+        derivatives = np.array([0.02, 0.01, 0.0, 0.0, 0.01])
+
+        modified = intervention.modify_derivatives(
+            derivatives, state, t=10, params=params
+        )
+
+        # Population effect: -0.01 * N = -0.005
+        assert modified[0] == pytest.approx(0.02 - 0.005)
+
+
+class TestFrontierExpansion:
+    """Tests for FrontierExpansion intervention."""
+
+    @pytest.fixture
+    def params(self):
+        return SDTParams(K_0=1.0, r_max=0.02)
+
+    def test_expansion_effects(self, params):
+        """Expansion boosts capacity and reduces elite competition."""
+        intervention = FrontierExpansion(
+            name="Expansion",
+            start_time=0,
+            carrying_capacity_boost=0.1,
+            elite_opportunity_boost=0.01,
+        )
+        # N/K > 0.7 to trigger capacity relief
+        state = np.array([0.8, 0.1, 1.0, 1.0, 0.1])
+        derivatives = np.array([0.01, 0.01, 0.0, 0.0, 0.01])
+
+        modified = intervention.modify_derivatives(
+            derivatives, state, t=10, params=params
+        )
+
+        # Capacity relief: 0.1 * r_max * N = 0.1 * 0.02 * 0.8 = 0.0016
+        assert modified[0] > 0.01
+        # Elite opportunity: -0.01 * E = -0.001
+        assert modified[1] == pytest.approx(0.01 - 0.001)
+        # Wage boost: 0.01 * W = 0.01
+        assert modified[2] == pytest.approx(0.01)
+
+
+class TestInstitutionalReform:
+    """Tests for InstitutionalReform intervention."""
+
+    @pytest.fixture
+    def params(self):
+        return SDTParams(rho=0.2, epsilon=0.05)
+
+    def test_reform_effects(self, params):
+        """Reform reduces instability and improves state efficiency."""
+        intervention = InstitutionalReform(
+            name="Reform",
+            start_time=0,
+            legitimacy_boost=0.02,
+            efficiency_boost=0.02,
+            elite_restraint=0.01,
+        )
+        state = np.array([0.5, 0.1, 1.0, 1.0, 0.1])  # N=0.5, E=0.1, W=1.0
+        derivatives = np.array([0.01, 0.01, 0.0, 0.0, 0.05])  # dpsi/dt = 0.05
+
+        modified = intervention.modify_derivatives(
+            derivatives, state, t=10, params=params
+        )
+
+        # Legitimacy: dpsi *= (1 - 0.02)
+        assert modified[4] == pytest.approx(0.05 * 0.98)
+        # Efficiency: 0.02 * rho * W * N = 0.02 * 0.2 * 1.0 * 0.5 = 0.002
+        # Elite restraint: 0.01 * epsilon * E = 0.01 * 0.05 * 0.1 = 0.00005
+        assert modified[3] == pytest.approx(0.002 + 0.00005)
+
+
+class TestCompositeIntervention:
+    """Tests for CompositeIntervention."""
+
+    @pytest.fixture
+    def params(self):
+        return SDTParams(W_0=1.0, E_0=0.1)
+
+    def test_composite_applies_all(self, params):
+        """Composite applies all constituent interventions."""
+        composite = CompositeIntervention(
+            name="Package",
+            start_time=0,
+            interventions=[
+                WageFloor(name="Floor", start_time=0, min_wage_ratio=0.8),
+                EliteCap(name="Cap", start_time=0, max_elite_ratio=1.5),
+            ],
+        )
+
+        # State with low wage and high elite
+        state = np.array([0.5, 0.2, 0.5, 1.0, 0.1])
+        modified = composite.modify_state(state, t=10, params=params)
+
+        # Wage floor enforced
+        assert modified[2] == pytest.approx(0.8)
+        # Elite cap enforced
+        assert modified[1] == pytest.approx(0.15)
+
+
+class TestFactoryFunctions:
+    """Tests for factory functions."""
+
+    def test_create_elite_management_policy(self):
+        """Factory creates correct elite management policy."""
+        policy = create_elite_management_policy(
+            start_time=50,
+            cap_ratio=1.5,
+            purge_fraction=0.2,
+        )
+        assert isinstance(policy, CompositeIntervention)
+        assert len(policy.interventions) == 2
+
+    def test_create_welfare_policy(self):
+        """Factory creates correct welfare policy."""
+        policy = create_welfare_policy(
+            start_time=50,
+            wage_floor=0.8,
+            wage_boost=0.01,
+        )
+        assert isinstance(policy, CompositeIntervention)
+        assert len(policy.interventions) == 2


### PR DESCRIPTION
## Summary

Implements a framework for running counterfactual policy simulations and extracting actionable recommendations from SDT models. This enables "what-if" analysis: given a historical trajectory, what policies might have changed outcomes?

Key deliverables:
- **11 intervention types**: Elite management (caps, purges), popular welfare (wage floors, boosts), fiscal policy (progressive taxation, austerity, stimulus), demographics (migration, frontier expansion), and institutional reform
- **Counterfactual engine**: Run simulations with interventions applied at specified times
- **Analysis tools**: Compare outcomes, rank interventions by effectiveness, generate policy recommendations with historical precedents

## Test plan

- [ ] All 59 policy module tests pass (`pytest tests/policy/`)
- [ ] Existing simulation tests still pass (`pytest tests/test_simulation.py`)
- [ ] Code passes ruff format and lint checks
- [ ] Example usage works:
  ```python
  from cliodynamics.policy import CounterfactualEngine, EliteCap, OutcomeComparison
  from cliodynamics.models import SDTModel
  
  model = SDTModel()
  engine = CounterfactualEngine(model)
  baseline = engine.run_baseline({'N': 0.5, 'E': 0.05, 'W': 1.0, 'S': 1.0, 'psi': 0.0}, (0, 200))
  intervention = EliteCap(name="Elite cap", start_time=50, max_elite_ratio=1.5)
  result = engine.run_intervention(baseline, intervention)
  comparison = OutcomeComparison(baseline, result)
  print(comparison.summary())
  ```

Closes #41

Generated with [Claude Code](https://claude.com/claude-code)