### PR TITLE
Fix Explorer v2 GitHub Pages 404 errors - correct base path

### DIFF
--- a/docs/explorer-v2/index.html
+++ b/docs/explorer-v2/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" href="data:," />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cliodynamics Explorer v2 - Interactive SDT Simulation</title>
     <meta name="description" content="Interactive exploration of Structural-Demographic Theory dynamics using TypeScript and React." />
-    <script type="module" crossorigin src="/explorer-v2/assets/index-AKwMrVzC.js"></script>
-    <link rel="stylesheet" crossorigin href="/explorer-v2/assets/index-FQ--zElU.css">
+    <script type="module" crossorigin src="/turchin/explorer-v2/assets/index-AKwMrVzC.js"></script>
+    <link rel="stylesheet" crossorigin href="/turchin/explorer-v2/assets/index-FQ--zElU.css">
   </head>
   <body>
     <div id="root"></div>

--- a/explorer-v2/index.html
+++ b/explorer-v2/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" href="data:," />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cliodynamics Explorer v2 - Interactive SDT Simulation</title>
     <meta name="description" content="Interactive exploration of Structural-Demographic Theory dynamics using TypeScript and React." />

--- a/explorer-v2/vite.config.ts
+++ b/explorer-v2/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/explorer-v2/',
+  base: '/turchin/explorer-v2/',
   build: {
     outDir: 'dist',
     sourcemap: true,

--- a/explorer-v2/vite.config.ts
+++ b/explorer-v2/vite.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [react()],
-  base: '/turchin/explorer-v2/',
+  base: mode === 'production' ? '/turchin/explorer-v2/' : '/',
   build: {
     outDir: 'dist',
     sourcemap: true,
@@ -12,4 +12,4 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
   },
-})
+}))


### PR DESCRIPTION
## Summary
- Updated Vite base path from `/explorer-v2/` to `/turchin/explorer-v2/` to match the GitHub Pages deployment URL
- Fixed favicon reference that pointed to a non-existent `/favicon.svg` file
- Rebuilt and redeployed to `docs/explorer-v2/`

## Test plan
- [ ] Verify `docs/explorer-v2/index.html` references `/turchin/explorer-v2/assets/...` paths
- [ ] After merge, confirm https://bedwards.github.io/turchin/explorer-v2/ loads without 404 errors

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)