### PR TITLE
Add Phase 2 Rome MVP: assets, themed controls, enhanced particles, environment

### DIFF
--- a/roblox/rome-assets/rome-game/src/client/Environment.client.luau
+++ b/roblox/rome-assets/rome-game/src/client/Environment.client.luau
@@ -1,0 +1,314 @@
+--!strict
+--[[
+    Environment.client.luau
+
+    Environmental visual effects that respond to game state.
+
+    Features:
+    - Building condition visuals: darken/brighten based on State Health (S)
+    - Market "busyness" indicator based on Wages (W)
+    - Ambient particle dust in sunbeams
+    - Visual feedback reinforcing the cliodynamics simulation
+
+    This creates an immersive Rome where the health of the state
+    is reflected in the environment itself.
+]]
+
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Lighting = game:GetService("Lighting")
+local TweenService = game:GetService("TweenService")
+local RunService = game:GetService("RunService")
+
+-- Wait for RemoteEvents
+local RemoteEvents = ReplicatedStorage:WaitForChild("RemoteEvents")
+local StateUpdateEvent = RemoteEvents:WaitForChild("StateUpdate")
+
+print("==============================================")
+print("  ENVIRONMENT SYSTEM INITIALIZING")
+print("==============================================")
+print("")
+
+-- Configuration
+local TWEEN_DURATION = 2.0
+local DUST_PARTICLE_COUNT = 50
+local SUNBEAM_UPDATE_RATE = 0.5 -- How often to update dust positions
+
+-- Current state
+local currentStateHealth: number = 0.8
+local currentWages: number = 0.7
+-- currentPsi available for future PSI-based environmental effects
+
+-- Tween info
+local TWEEN_INFO = TweenInfo.new(TWEEN_DURATION, Enum.EasingStyle.Quad, Enum.EasingDirection.InOut)
+
+-- Track building parts for darkening
+local buildingParts: { [BasePart]: Color3 } = {} -- Part -> original color
+local marketStalls: { BasePart } = {}
+
+-- Dust particles container
+local dustFolder: Folder?
+local dustParticles: { Part } = {}
+
+--[[
+    Find and catalog all building parts for visual effects.
+]]
+local function catalogBuildings()
+    -- Wait for buildings to be placed
+    task.wait(8)
+
+    -- Find Roman buildings folder
+    local romanBuildings = workspace:FindFirstChild("RomanBuildings")
+    if romanBuildings then
+        for _, child in ipairs(romanBuildings:GetDescendants()) do
+            if child:IsA("BasePart") then
+                buildingParts[child] = child.Color
+            end
+        end
+        print(string.format("[Environment] Cataloged %d building parts", #buildingParts))
+    end
+
+    -- Find procedural buildings folder
+    local proceduralBuildings = workspace:FindFirstChild("ProceduralBuildings")
+    if proceduralBuildings then
+        for _, child in ipairs(proceduralBuildings:GetDescendants()) do
+            if child:IsA("BasePart") then
+                buildingParts[child] = child.Color
+            end
+        end
+    end
+
+    -- Find market stalls specifically
+    if romanBuildings then
+        for _, child in ipairs(romanBuildings:GetChildren()) do
+            if child.Name:find("MarketStall") then
+                for _, part in ipairs(child:GetDescendants()) do
+                    if part:IsA("BasePart") then
+                        table.insert(marketStalls, part)
+                    end
+                end
+            end
+        end
+    end
+
+    print(string.format("[Environment] Found %d market stall parts", #marketStalls))
+end
+
+--[[
+    Darken or brighten a color by a factor.
+    Factor > 1 = brighter, Factor < 1 = darker
+]]
+local function adjustBrightness(color: Color3, factor: number): Color3
+    return Color3.new(
+        math.clamp(color.R * factor, 0, 1),
+        math.clamp(color.G * factor, 0, 1),
+        math.clamp(color.B * factor, 0, 1)
+    )
+end
+
+--[[
+    Update building colors based on State Health.
+    Low health = darker, grayer buildings (decay)
+    High health = bright, clean buildings (prosperity)
+]]
+local function updateBuildingCondition(stateHealth: number)
+    -- Map state health (0.1 to 1.0) to brightness factor (0.5 to 1.0)
+    local normalizedHealth = math.clamp((stateHealth - 0.1) / 0.9, 0, 1)
+    local brightnessFactor = 0.5 + normalizedHealth * 0.5
+
+    -- Also desaturate during low health
+    local saturationFactor = 0.6 + normalizedHealth * 0.4
+
+    for part, originalColor in pairs(buildingParts) do
+        if part and part.Parent then
+            -- Adjust brightness
+            local adjustedColor = adjustBrightness(originalColor, brightnessFactor)
+
+            -- Apply desaturation by mixing with gray
+            local gray = (adjustedColor.R + adjustedColor.G + adjustedColor.B) / 3
+            local grayColor = Color3.new(gray, gray, gray)
+
+            local finalColor = Color3.new(
+                adjustedColor.R * saturationFactor + grayColor.R * (1 - saturationFactor),
+                adjustedColor.G * saturationFactor + grayColor.G * (1 - saturationFactor),
+                adjustedColor.B * saturationFactor + grayColor.B * (1 - saturationFactor)
+            )
+
+            -- Tween to new color
+            local tween = TweenService:Create(part, TWEEN_INFO, {
+                Color = finalColor,
+            })
+            tween:Play()
+        end
+    end
+end
+
+--[[
+    Update market "busyness" visual based on wages.
+    Higher wages = more active market (brighter stalls)
+    Lower wages = quieter market (dimmer stalls)
+]]
+local function updateMarketBusyness(wages: number)
+    if #marketStalls == 0 then
+        return
+    end
+
+    -- Map wages (0.1 to 1.0) to pulsing intensity
+    local normalizedWages = math.clamp((wages - 0.1) / 0.9, 0, 1)
+
+    -- Brightness factor for market stalls
+    local brightness = 0.7 + normalizedWages * 0.5 -- 0.7 to 1.2
+
+    for _, stall in ipairs(marketStalls) do
+        if stall and stall.Parent then
+            -- Add a slight color shift toward warm tones when busy
+            local warmth = normalizedWages * 0.1
+            local baseColor = buildingParts[stall] or stall.Color
+
+            local adjustedColor = Color3.new(
+                math.clamp(baseColor.R * brightness + warmth, 0, 1),
+                math.clamp(baseColor.G * brightness, 0, 1),
+                math.clamp(baseColor.B * brightness - warmth * 0.5, 0, 1)
+            )
+
+            local tween = TweenService:Create(stall, TWEEN_INFO, {
+                Color = adjustedColor,
+            })
+            tween:Play()
+        end
+    end
+end
+
+--[[
+    Create ambient dust particles floating in sunbeams.
+]]
+local function createDustParticles()
+    dustFolder = Instance.new("Folder")
+    dustFolder.Name = "AmbientDust"
+    dustFolder.Parent = workspace
+
+    -- Create dust particles
+    for i = 1, DUST_PARTICLE_COUNT do
+        local dust = Instance.new("Part")
+        dust.Name = "Dust_" .. i
+        dust.Shape = Enum.PartType.Ball
+        dust.Size = Vector3.new(0.3, 0.3, 0.3)
+        dust.Material = Enum.Material.Neon
+        dust.Color = Color3.fromRGB(255, 250, 220) -- Warm white
+        dust.Transparency = 0.6
+        dust.Anchored = true
+        dust.CanCollide = false
+        dust.CastShadow = false
+
+        -- Random starting position (will be updated)
+        dust.Position = Vector3.new(
+            math.random(-50, 50),
+            math.random(5, 30),
+            math.random(-50, 50)
+        )
+
+        dust.Parent = dustFolder
+        table.insert(dustParticles, dust)
+    end
+
+    print(string.format("[Environment] Created %d ambient dust particles", DUST_PARTICLE_COUNT))
+end
+
+--[[
+    Update dust particle positions to float in sunbeams.
+]]
+local function updateDustParticles(_dt: number)
+    -- Get sun direction from lighting
+    local sunDirection = Vector3.new(
+        math.sin(math.rad(Lighting.ClockTime * 15)),
+        0.5,
+        math.cos(math.rad(Lighting.ClockTime * 15))
+    ).Unit
+
+    for i, dust in ipairs(dustParticles) do
+        if dust and dust.Parent then
+            local pos = dust.Position
+
+            -- Gentle floating motion
+            local time = os.clock() + i * 0.5
+            local floatX = math.sin(time * 0.3) * 0.02
+            local floatY = math.sin(time * 0.5) * 0.01
+            local floatZ = math.cos(time * 0.4) * 0.02
+
+            -- Slowly drift in sunbeam direction
+            local drift = sunDirection * 0.01
+
+            local newPos = Vector3.new(
+                pos.X + floatX + drift.X,
+                pos.Y + floatY,
+                pos.Z + floatZ + drift.Z
+            )
+
+            -- Reset if out of bounds
+            if newPos.Y < 3 or newPos.Y > 40 or math.abs(newPos.X) > 100 or math.abs(newPos.Z) > 100 then
+                newPos = Vector3.new(
+                    math.random(-50, 50),
+                    math.random(10, 35),
+                    math.random(-50, 50)
+                )
+            end
+
+            dust.Position = newPos
+
+            -- Adjust transparency based on height (brighter in sunbeams)
+            local heightFactor = math.clamp((pos.Y - 5) / 30, 0, 1)
+            dust.Transparency = 0.4 + (1 - heightFactor) * 0.4
+        end
+    end
+end
+
+--[[
+    Handle state updates from server.
+]]
+StateUpdateEvent.OnClientEvent:Connect(function(state: { N: number, E: number, W: number, S: number, psi: number })
+    local oldStateHealth = currentStateHealth
+    local oldWages = currentWages
+
+    currentStateHealth = state.S
+    currentWages = state.W
+    -- state.psi available for future PSI-based effects
+
+    -- Update building condition if state health changed significantly
+    if math.abs(oldStateHealth - currentStateHealth) > 0.05 then
+        updateBuildingCondition(currentStateHealth)
+    end
+
+    -- Update market busyness if wages changed significantly
+    if math.abs(oldWages - currentWages) > 0.05 then
+        updateMarketBusyness(currentWages)
+    end
+end)
+
+-- Initialize
+task.spawn(function()
+    catalogBuildings()
+
+    -- Initial update
+    updateBuildingCondition(currentStateHealth)
+    updateMarketBusyness(currentWages)
+end)
+
+-- Create ambient dust
+createDustParticles()
+
+-- Dust particle update loop
+local dustAccumulator = 0
+RunService.Heartbeat:Connect(function(dt: number)
+    dustAccumulator = dustAccumulator + dt
+
+    if dustAccumulator >= SUNBEAM_UPDATE_RATE then
+        updateDustParticles(dustAccumulator)
+        dustAccumulator = 0
+    end
+end)
+
+print("")
+print("Environment system running!")
+print("  Building condition responds to State Health (S)")
+print("  Market busyness responds to Wages (W)")
+print("  Ambient dust particles floating in sunbeams")
+print(string.format("  Initial state: S=%.2f, W=%.2f", currentStateHealth, currentWages))

--- a/roblox/rome-assets/rome-game/src/client/Particles.client.luau
+++ b/roblox/rome-assets/rome-game/src/client/Particles.client.luau
@@ -7,10 +7,13 @@
     Features:
     - 1000+ glowing spheres floating at ground level
     - Blue = commoners, Gold = elites
-    - Optimized wandering movement with spatial updates
+    - Elites cluster in Forum zone when E is high
+    - Commoners gather near market stalls
+    - Color shift: gold -> orange -> red as elite competition increases
+    - Crisis makes particles move erratically (jitter)
+    - Simple collision avoidance between particles
     - LOD (Level of Detail) system for distant particles
-    - Batch position updates for performance
-    - Target: 60fps with 1000 particles
+    - Optimized wandering movement with spatial updates
 
     Performance Optimizations:
     - Reduced update frequency for distant particles
@@ -27,6 +30,7 @@ local Players = game:GetService("Players")
 -- Wait for shared modules
 local Shared = ReplicatedStorage:WaitForChild("Shared")
 local TerrainUtils = require(Shared:WaitForChild("TerrainUtils"))
+local TerrainGenerator = require(Shared:WaitForChild("TerrainGenerator"))
 
 -- Wait for RemoteEvents
 local RemoteEvents = ReplicatedStorage:WaitForChild("RemoteEvents")
@@ -52,10 +56,24 @@ local VERY_FAR_UPDATE_RATE = 5 -- Very far particles update 5 Hz
 
 -- Colors
 local COMMONER_COLOR = Color3.fromRGB(100, 150, 255) -- Blue
-local ELITE_COLOR = Color3.fromRGB(255, 215, 0) -- Gold
+local ELITE_COLOR_PEACEFUL = Color3.fromRGB(255, 215, 0) -- Gold
+local ELITE_COLOR_TENSE = Color3.fromRGB(255, 165, 0) -- Orange
+local ELITE_COLOR_CRISIS = Color3.fromRGB(255, 80, 50) -- Red-orange
 
 -- Smaller size for distant particles (LOD)
 local LOD_PARTICLE_SIZE = 1.5
+
+-- Zone locations for clustering
+local FORUM_CENTER = { x = 0, z = 0 }
+local MARKET_CENTER = { x = 40, z = -80 }
+
+-- Clustering parameters
+local CLUSTER_STRENGTH = 0.3 -- How strongly particles cluster
+local CLUSTER_RANGE = 60 -- Range within which to cluster
+local AVOIDANCE_DISTANCE = 4 -- Minimum distance between particles
+local AVOIDANCE_STRENGTH = 0.5
+-- JITTER_BASE could be used for constant jitter during normal times
+local JITTER_CRISIS_MAX = 3 -- Max jitter during crisis
 
 -- Particle state
 type Particle = {
@@ -67,10 +85,14 @@ type Particle = {
     currentZ: number,
     lastUpdateTime: number,
     distanceToPlayer: number,
+    velocityX: number,
+    velocityZ: number,
 }
 
 local particles: { Particle } = {}
 local currentEliteRatio = ELITE_RATIO
+local currentPsi = 0.05
+local currentE = 0.1
 
 -- Container for particles
 local particleFolder: Folder
@@ -78,11 +100,15 @@ local particleFolder: Folder
 -- Local player reference
 local localPlayer = Players.LocalPlayer
 
+-- Flat zones available for future zone-based behavior
+local _flatZones = TerrainGenerator.getFlatZones()
+
 print("==============================================")
-print("  HIGH-PERFORMANCE PARTICLE SYSTEM")
+print("  ENHANCED PARTICLE SYSTEM")
 print("==============================================")
 print("")
 print(string.format("  Target: %d particles at 60 FPS", TOTAL_PARTICLES))
+print("  Features: Clustering, collision avoidance, crisis jitter")
 print("")
 
 --[[
@@ -92,6 +118,32 @@ local function initializeContainer()
     particleFolder = Instance.new("Folder")
     particleFolder.Name = "PopulationParticles"
     particleFolder.Parent = workspace
+end
+
+--[[
+    Get elite color based on current PSI (elite competition intensity).
+]]
+local function getEliteColor(psi: number): Color3
+    if psi < 0.3 then
+        -- Peaceful: gold
+        local t = psi / 0.3
+        return Color3.new(
+            ELITE_COLOR_PEACEFUL.R + (ELITE_COLOR_TENSE.R - ELITE_COLOR_PEACEFUL.R) * t,
+            ELITE_COLOR_PEACEFUL.G + (ELITE_COLOR_TENSE.G - ELITE_COLOR_PEACEFUL.G) * t,
+            ELITE_COLOR_PEACEFUL.B + (ELITE_COLOR_TENSE.B - ELITE_COLOR_PEACEFUL.B) * t
+        )
+    elseif psi < 0.6 then
+        -- Tense: orange
+        local t = (psi - 0.3) / 0.3
+        return Color3.new(
+            ELITE_COLOR_TENSE.R + (ELITE_COLOR_CRISIS.R - ELITE_COLOR_TENSE.R) * t,
+            ELITE_COLOR_TENSE.G + (ELITE_COLOR_CRISIS.G - ELITE_COLOR_TENSE.G) * t,
+            ELITE_COLOR_TENSE.B + (ELITE_COLOR_CRISIS.B - ELITE_COLOR_TENSE.B) * t
+        )
+    else
+        -- Crisis: red
+        return ELITE_COLOR_CRISIS
+    end
 end
 
 --[[
@@ -106,7 +158,7 @@ local function createParticle(index: number, isElite: boolean): Particle
     part.Shape = Enum.PartType.Ball
     part.Size = Vector3.new(PARTICLE_SIZE, PARTICLE_SIZE, PARTICLE_SIZE)
     part.Material = Enum.Material.Neon
-    part.Color = if isElite then ELITE_COLOR else COMMONER_COLOR
+    part.Color = if isElite then getEliteColor(currentPsi) else COMMONER_COLOR
     part.Anchored = true
     part.CanCollide = false
     part.CastShadow = false
@@ -130,6 +182,8 @@ local function createParticle(index: number, isElite: boolean): Particle
         currentZ = z,
         lastUpdateTime = 0,
         distanceToPlayer = 0,
+        velocityX = 0,
+        velocityZ = 0,
     }
 end
 
@@ -172,6 +226,86 @@ local function initializeParticles()
     print(string.format("  Created %d elites (gold)", eliteCount))
     print(string.format("  Created %d commoners (blue)", commonerCount))
     print(string.format("  Total: %d particles", #particles))
+end
+
+--[[
+    Get cluster target for a particle based on its type and current state.
+]]
+local function getClusterTarget(particle: Particle): (number, number)
+    if particle.isElite then
+        -- Elites cluster at Forum when E is high
+        local clusterIntensity = math.clamp(currentE / 0.3, 0, 1) * CLUSTER_STRENGTH
+        if clusterIntensity > 0.1 then
+            local dx = FORUM_CENTER.x - particle.currentX
+            local dz = FORUM_CENTER.z - particle.currentZ
+            local dist = math.sqrt(dx * dx + dz * dz)
+
+            if dist < CLUSTER_RANGE then
+                return particle.targetX + dx * clusterIntensity, particle.targetZ + dz * clusterIntensity
+            end
+        end
+    else
+        -- Commoners cluster near Market
+        local clusterIntensity = CLUSTER_STRENGTH * 0.5
+        local dx = MARKET_CENTER.x - particle.currentX
+        local dz = MARKET_CENTER.z - particle.currentZ
+        local dist = math.sqrt(dx * dx + dz * dz)
+
+        if dist < CLUSTER_RANGE then
+            return particle.targetX + dx * clusterIntensity, particle.targetZ + dz * clusterIntensity
+        end
+    end
+
+    return particle.targetX, particle.targetZ
+end
+
+--[[
+    Calculate collision avoidance vector from nearby particles.
+    Uses a simple sampling approach for performance.
+]]
+local function getAvoidanceVector(particle: Particle, index: number): (number, number)
+    local avoidX, avoidZ = 0, 0
+    local nearbyCount = 0
+
+    -- Sample a few nearby particles (not all, for performance)
+    local sampleStep = math.max(1, math.floor(#particles / 50))
+
+    for i = 1, #particles, sampleStep do
+        if i == index then
+            continue
+        end
+
+        local other = particles[i]
+        local dx = particle.currentX - other.currentX
+        local dz = particle.currentZ - other.currentZ
+        local distSq = dx * dx + dz * dz
+
+        if distSq < AVOIDANCE_DISTANCE * AVOIDANCE_DISTANCE and distSq > 0.1 then
+            local dist = math.sqrt(distSq)
+            local strength = (AVOIDANCE_DISTANCE - dist) / AVOIDANCE_DISTANCE
+            avoidX = avoidX + (dx / dist) * strength
+            avoidZ = avoidZ + (dz / dist) * strength
+            nearbyCount = nearbyCount + 1
+        end
+    end
+
+    if nearbyCount > 0 then
+        return avoidX * AVOIDANCE_STRENGTH, avoidZ * AVOIDANCE_STRENGTH
+    end
+
+    return 0, 0
+end
+
+--[[
+    Get crisis jitter amount based on PSI.
+]]
+local function getCrisisJitter(): (number, number)
+    if currentPsi < 0.4 then
+        return 0, 0
+    end
+
+    local jitterStrength = (currentPsi - 0.4) / 0.6 * JITTER_CRISIS_MAX
+    return (math.random() - 0.5) * jitterStrength, (math.random() - 0.5) * jitterStrength
 end
 
 --[[
@@ -227,13 +361,16 @@ local function getUpdateInterval(distance: number): number
 end
 
 --[[
-    Update particle position toward target.
+    Update particle position toward target with clustering, avoidance, and jitter.
     Returns true if position changed.
 ]]
-local function updateParticlePosition(particle: Particle, dt: number): boolean
+local function updateParticlePosition(particle: Particle, dt: number, index: number): boolean
+    -- Get cluster-modified target
+    local clusterX, clusterZ = getClusterTarget(particle)
+
     -- Calculate direction to target
-    local dx = particle.targetX - particle.currentX
-    local dz = particle.targetZ - particle.currentZ
+    local dx = clusterX - particle.currentX
+    local dz = clusterZ - particle.currentZ
     local distance = math.sqrt(dx * dx + dz * dz)
 
     -- If close to target, pick new target
@@ -242,7 +379,13 @@ local function updateParticlePosition(particle: Particle, dt: number): boolean
         return false
     end
 
-    -- Move toward target
+    -- Get avoidance vector
+    local avoidX, avoidZ = getAvoidanceVector(particle, index)
+
+    -- Get crisis jitter
+    local jitterX, jitterZ = getCrisisJitter()
+
+    -- Calculate movement direction
     local moveDistance = WANDER_SPEED * dt
     if moveDistance > distance then
         moveDistance = distance
@@ -251,8 +394,13 @@ local function updateParticlePosition(particle: Particle, dt: number): boolean
     local dirX = dx / distance
     local dirZ = dz / distance
 
-    particle.currentX = particle.currentX + dirX * moveDistance
-    particle.currentZ = particle.currentZ + dirZ * moveDistance
+    -- Apply movement with avoidance and jitter
+    particle.currentX = particle.currentX + (dirX * moveDistance) + avoidX + jitterX
+    particle.currentZ = particle.currentZ + (dirZ * moveDistance) + avoidZ + jitterZ
+
+    -- Clamp to map bounds
+    particle.currentX = math.clamp(particle.currentX, -MAP_HALF_SIZE, MAP_HALF_SIZE)
+    particle.currentZ = math.clamp(particle.currentZ, -MAP_HALF_SIZE, MAP_HALF_SIZE)
 
     return true
 end
@@ -285,6 +433,19 @@ local function applyLOD(particle: Particle)
 end
 
 --[[
+    Update elite colors based on current PSI.
+]]
+local function updateEliteColors()
+    local eliteColor = getEliteColor(currentPsi)
+
+    for _, particle in ipairs(particles) do
+        if particle.isElite then
+            particle.part.Color = eliteColor
+        end
+    end
+end
+
+--[[
     Update elite/commoner ratio based on state from server.
 ]]
 local function updateEliteRatio(newRatio: number)
@@ -305,6 +466,7 @@ local function updateEliteRatio(newRatio: number)
 
     -- Convert particles as needed
     local difference = targetEliteCount - currentEliteCount
+    local eliteColor = getEliteColor(currentPsi)
 
     if difference > 0 then
         -- Need more elites - convert commoners
@@ -312,7 +474,7 @@ local function updateEliteRatio(newRatio: number)
         for _, particle in ipairs(particles) do
             if not particle.isElite and converted < difference then
                 particle.isElite = true
-                particle.part.Color = ELITE_COLOR
+                particle.part.Color = eliteColor
                 converted = converted + 1
             end
         end
@@ -334,10 +496,19 @@ end
     Handle state updates from server.
 ]]
 StateUpdateEvent.OnClientEvent:Connect(function(state: { N: number, E: number, W: number, S: number, psi: number })
+    local oldPsi = currentPsi
+    currentPsi = state.psi
+    currentE = state.E
+
     -- Elite ratio is E relative to typical elite population
     -- E ranges from 0.01 to 0.5, normalize to 0-0.3 range for particle display
     local eliteRatio = math.clamp(state.E / 0.5 * 0.3, 0.02, 0.3)
     updateEliteRatio(eliteRatio)
+
+    -- Update elite colors if PSI changed significantly
+    if math.abs(oldPsi - currentPsi) > 0.05 then
+        updateEliteColors()
+    end
 end)
 
 -- Initialize
@@ -384,8 +555,8 @@ RunService.Heartbeat:Connect(function(_dt: number)
         local timeSinceUpdate = currentTime - particle.lastUpdateTime
 
         if timeSinceUpdate >= updateInterval then
-            -- Update position
-            if updateParticlePosition(particle, timeSinceUpdate) then
+            -- Update position with clustering, avoidance, and jitter
+            if updateParticlePosition(particle, timeSinceUpdate, i) then
                 updateParticlePart(particle)
             end
 
@@ -426,9 +597,10 @@ RunService.Heartbeat:Connect(function(_dt: number)
 end)
 
 print("")
-print("Particle system running!")
+print("Enhanced particle system running!")
 print(string.format("  %d particles with LOD optimization", TOTAL_PARTICLES))
-print(
-    string.format("  LOD distances: near=%d, far=%d, cull=%d", LOD_NEAR_DISTANCE, LOD_FAR_DISTANCE, LOD_CULL_DISTANCE)
-)
+print(string.format("  LOD distances: near=%d, far=%d, cull=%d", LOD_NEAR_DISTANCE, LOD_FAR_DISTANCE, LOD_CULL_DISTANCE))
+print("  Elite clustering at Forum")
+print("  Commoner clustering at Market")
+print("  Crisis jitter enabled")
 print("  Performance target: 60 FPS")

--- a/roblox/rome-assets/rome-game/src/client/SoundEffects.client.luau
+++ b/roblox/rome-assets/rome-game/src/client/SoundEffects.client.luau
@@ -1,0 +1,236 @@
+--!strict
+--[[
+    SoundEffects.client.luau
+
+    Sound effects system for immersive Roman atmosphere.
+
+    Features:
+    - Pressure plate step sounds
+    - Ambient crowd murmur (volume scales with population)
+    - Environmental ambience (birds, wind)
+    - Sounds respond to game state
+
+    Sound Design:
+    - Peaceful: Birds, gentle wind, distant crowd
+    - Tense: Louder crowd murmur, less birds
+    - Crisis: Agitated crowd, strong wind
+]]
+
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local SoundService = game:GetService("SoundService")
+local TweenService = game:GetService("TweenService")
+local Players = game:GetService("Players")
+
+-- Wait for shared modules
+local Shared = ReplicatedStorage:WaitForChild("Shared")
+local AssetConfig = require(Shared:WaitForChild("AssetConfig"))
+
+-- Wait for RemoteEvents
+local RemoteEvents = ReplicatedStorage:WaitForChild("RemoteEvents")
+local StateUpdateEvent = RemoteEvents:WaitForChild("StateUpdate")
+local ControlInputEvent = RemoteEvents:WaitForChild("ControlInput")
+
+print("==============================================")
+print("  SOUND EFFECTS SYSTEM INITIALIZING")
+print("==============================================")
+print("")
+
+-- Configuration
+local TWEEN_DURATION = 2.0
+-- AMBIENT_UPDATE_RATE could be used for periodic volume updates
+
+-- Current state
+local currentPsi: number = 0.05
+local currentPopulation: number = 0.5
+
+-- Tween info
+local TWEEN_INFO = TweenInfo.new(TWEEN_DURATION, Enum.EasingStyle.Quad, Enum.EasingDirection.InOut)
+
+-- Sound instances
+local ambientSounds: { [string]: Sound } = {}
+local controlStepSound: Sound?
+
+-- Local player reference (for future positional audio)
+local _localPlayer = Players.LocalPlayer
+
+--[[
+    Create an ambient sound with looping.
+]]
+local function createAmbientSound(name: string, soundId: string, defaultVolume: number): Sound
+    local sound = Instance.new("Sound")
+    sound.Name = name
+    sound.SoundId = soundId
+    sound.Volume = defaultVolume
+    sound.Looped = true
+    sound.RollOffMode = Enum.RollOffMode.Linear
+    sound.RollOffMaxDistance = 500
+    sound.RollOffMinDistance = 10
+
+    -- Parent to SoundService for global ambient
+    sound.Parent = SoundService
+
+    return sound
+end
+
+--[[
+    Create a one-shot sound effect.
+]]
+local function createOneShotSound(name: string, soundId: string, volume: number): Sound
+    local sound = Instance.new("Sound")
+    sound.Name = name
+    sound.SoundId = soundId
+    sound.Volume = volume
+    sound.Looped = false
+    sound.Parent = SoundService
+
+    return sound
+end
+
+--[[
+    Initialize all sound effects.
+]]
+local function initializeSounds()
+    -- Ambient crowd murmur (volume scales with population and PSI)
+    ambientSounds.crowd = createAmbientSound("CrowdMurmur", AssetConfig.Sounds.CrowdMurmur, 0.2)
+
+    -- Birds (louder during peaceful times)
+    ambientSounds.birds = createAmbientSound("Birds", AssetConfig.Sounds.Birds, 0.3)
+
+    -- Wind (louder during crisis)
+    ambientSounds.wind = createAmbientSound("Wind", AssetConfig.Sounds.Wind, 0.1)
+
+    -- Control plate step sound (one-shot)
+    controlStepSound = createOneShotSound("PlateStep", AssetConfig.Sounds.PlateStep, 0.5)
+
+    print("[SoundEffects] Created ambient sounds:")
+    print("  - Crowd murmur")
+    print("  - Birds")
+    print("  - Wind")
+    print("  - Plate step")
+end
+
+--[[
+    Play the pressure plate step sound.
+]]
+local function playPlateStepSound()
+    if controlStepSound then
+        -- Clone for overlapping sounds
+        local soundClone = controlStepSound:Clone()
+        soundClone.Parent = SoundService
+        soundClone:Play()
+
+        -- Clean up after playing
+        soundClone.Ended:Connect(function()
+            soundClone:Destroy()
+        end)
+    end
+end
+
+--[[
+    Update ambient sound volumes based on game state.
+]]
+local function updateAmbientSounds(psi: number, population: number)
+    -- Crowd volume: louder with more population and higher stress
+    local crowdBase = 0.1 + population * 0.2 -- 0.1 to 0.3 based on population
+    local crowdStress = psi * 0.3 -- Add up to 0.3 for stress
+    local crowdVolume = math.clamp(crowdBase + crowdStress, 0.05, 0.5)
+
+    -- Birds volume: quieter during crisis
+    local birdsVolume = math.clamp(0.35 - psi * 0.3, 0.05, 0.35)
+
+    -- Wind volume: louder during crisis
+    local windVolume = math.clamp(0.05 + psi * 0.25, 0.05, 0.3)
+
+    -- Apply volume changes with tweening
+    if ambientSounds.crowd then
+        local tween = TweenService:Create(ambientSounds.crowd, TWEEN_INFO, {
+            Volume = crowdVolume,
+        })
+        tween:Play()
+    end
+
+    if ambientSounds.birds then
+        local tween = TweenService:Create(ambientSounds.birds, TWEEN_INFO, {
+            Volume = birdsVolume,
+        })
+        tween:Play()
+    end
+
+    if ambientSounds.wind then
+        local tween = TweenService:Create(ambientSounds.wind, TWEEN_INFO, {
+            Volume = windVolume,
+        })
+        tween:Play()
+    end
+end
+
+--[[
+    Update crowd pitch based on stress (higher pitch = more agitated).
+]]
+local function updateCrowdPitch(psi: number)
+    if ambientSounds.crowd then
+        -- Pitch: 0.9 (calm) to 1.2 (agitated)
+        local pitch = 0.9 + psi * 0.3
+
+        local tween = TweenService:Create(ambientSounds.crowd, TWEEN_INFO, {
+            PlaybackSpeed = pitch,
+        })
+        tween:Play()
+    end
+end
+
+--[[
+    Start all ambient sounds.
+]]
+local function startAmbientSounds()
+    for _, sound in pairs(ambientSounds) do
+        if not sound.IsPlaying then
+            sound:Play()
+        end
+    end
+
+    print("[SoundEffects] Ambient sounds playing")
+end
+
+--[[
+    Handle state updates from server.
+]]
+StateUpdateEvent.OnClientEvent:Connect(function(state: { N: number, E: number, W: number, S: number, psi: number })
+    local oldPsi = currentPsi
+
+    currentPsi = state.psi
+    currentPopulation = state.N
+
+    -- Update ambient volumes if PSI changed significantly
+    if math.abs(oldPsi - currentPsi) > 0.03 then
+        updateAmbientSounds(currentPsi, currentPopulation)
+        updateCrowdPitch(currentPsi)
+    end
+end)
+
+--[[
+    Handle control input events (for step sounds).
+]]
+ControlInputEvent.OnClientEvent:Connect(function(_controlType: string, isActivating: boolean)
+    if isActivating then
+        playPlateStepSound()
+    end
+end)
+
+-- Initialize
+initializeSounds()
+
+-- Wait a moment before starting sounds
+task.wait(2)
+startAmbientSounds()
+
+-- Initial volume update
+updateAmbientSounds(currentPsi, currentPopulation)
+
+print("")
+print("Sound effects system running!")
+print("  Crowd murmur scales with population and stress")
+print("  Bird sounds decrease during crisis")
+print("  Wind increases during crisis")
+print("  Plate step sounds on control activation")
+print(string.format("  Initial state: PSI=%.2f, N=%.2f", currentPsi, currentPopulation))

--- a/roblox/rome-assets/rome-game/src/client/Tutorial.client.luau
+++ b/roblox/rome-assets/rome-game/src/client/Tutorial.client.luau
@@ -1,0 +1,392 @@
+--!strict
+--[[
+    Tutorial.client.luau
+
+    3D tutorial hints system for guiding new players.
+
+    Features:
+    - Glowing path particles leading to first control
+    - Floating BillboardGui text above controls
+    - "Stand on green to increase" hint text
+    - Hints fade after player uses each control once
+    - Stores hint state locally (per session)
+
+    Tutorial Flow:
+    1. On first play, show glowing path to Forum (PSI control)
+    2. Show floating hint text above controls
+    3. Each control's hint fades after first use
+    4. Path particles fade after player reaches Forum
+]]
+
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local TweenService = game:GetService("TweenService")
+local RunService = game:GetService("RunService")
+local Players = game:GetService("Players")
+
+-- Wait for shared modules
+local Shared = ReplicatedStorage:WaitForChild("Shared")
+local AssetConfig = require(Shared:WaitForChild("AssetConfig"))
+local TerrainUtils = require(Shared:WaitForChild("TerrainUtils"))
+
+-- Wait for RemoteEvents
+local RemoteEvents = ReplicatedStorage:WaitForChild("RemoteEvents")
+local ControlInputEvent = RemoteEvents:WaitForChild("ControlInput")
+
+print("==============================================")
+print("  TUTORIAL SYSTEM INITIALIZING")
+print("==============================================")
+print("")
+
+-- Configuration
+local HINT_FADE_DURATION = 2.0
+local PATH_PARTICLE_COUNT = 20
+-- PATH_PARTICLE_SPACING could be used for variable-spaced particles
+
+-- Tutorial state (per session, not persisted)
+local tutorialState = {
+    pathShown = true,
+    controlsUsed = {
+        decrease_psi = false,
+        increase_psi = false,
+        decrease_alpha = false,
+        increase_alpha = false,
+        decrease_gamma = false,
+        increase_gamma = false,
+        decrease_delta = false,
+        increase_delta = false,
+    },
+    hintsVisible = true,
+}
+
+-- Control station locations (must match Controls.server.luau)
+local STATION_LOCATIONS = {
+    forum = { x = 0, z = 0, name = "POLITICAL STRESS" },
+    senateForum = { x = 30, z = -25, name = "SENATE SEATS" },
+    market = { x = 40, z = -80, name = "GRAIN DOLE" },
+    templeDistrict = { x = -80, z = 60, name = "TAX COLLECTORS" },
+}
+
+-- Tween info
+local FADE_TWEEN_INFO = TweenInfo.new(HINT_FADE_DURATION, Enum.EasingStyle.Quad, Enum.EasingDirection.Out)
+
+-- Local player
+local localPlayer = Players.LocalPlayer
+
+-- Containers
+local tutorialFolder: Folder?
+local pathParticles: { Part } = {}
+local hintBillboards: { BillboardGui } = {}
+
+--[[
+    Create a glowing path particle.
+]]
+local function createPathParticle(x: number, z: number, index: number): Part
+    local groundY = TerrainUtils.getGroundY(x, z)
+
+    local particle = Instance.new("Part")
+    particle.Name = "PathParticle_" .. index
+    particle.Shape = Enum.PartType.Ball
+    particle.Size = Vector3.new(1.5, 1.5, 1.5)
+    particle.Material = Enum.Material.Neon
+    particle.Color = AssetConfig.Tutorial.PathParticleColor
+    particle.Anchored = true
+    particle.CanCollide = false
+    particle.CastShadow = false
+    particle.Position = Vector3.new(x, groundY + 2, z)
+
+    -- Add pulsing light
+    local light = Instance.new("PointLight")
+    light.Name = "ParticleLight"
+    light.Color = AssetConfig.Tutorial.PathParticleColor
+    light.Brightness = 1
+    light.Range = 10
+    light.Parent = particle
+
+    return particle
+end
+
+--[[
+    Create path particles from spawn to Forum.
+]]
+local function createPathToForum()
+    if not tutorialFolder then
+        return
+    end
+
+    -- Calculate path from spawn (assumed 0, 0, -50) to Forum (0, 0)
+    local startX, startZ = 0, -50
+    local endX, endZ = STATION_LOCATIONS.forum.x, STATION_LOCATIONS.forum.z
+
+    for i = 1, PATH_PARTICLE_COUNT do
+        local t = (i - 1) / (PATH_PARTICLE_COUNT - 1)
+        local x = startX + (endX - startX) * t
+        local z = startZ + (endZ - startZ) * t
+
+        local particle = createPathParticle(x, z, i)
+        particle.Parent = tutorialFolder
+
+        table.insert(pathParticles, particle)
+    end
+
+    print(string.format("[Tutorial] Created %d path particles to Forum", PATH_PARTICLE_COUNT))
+end
+
+--[[
+    Animate path particles with pulsing glow.
+]]
+local function animatePathParticles(_dt: number)
+    local time = os.clock()
+
+    for i, particle in ipairs(pathParticles) do
+        if particle and particle.Parent then
+            -- Wave effect along path
+            local phase = time * 3 + i * 0.3
+            local scale = 0.8 + math.sin(phase) * 0.3
+
+            particle.Size = Vector3.new(1.5 * scale, 1.5 * scale, 1.5 * scale)
+
+            local light = particle:FindFirstChild("ParticleLight") :: PointLight?
+            if light then
+                light.Brightness = 0.8 + math.sin(phase) * 0.4
+            end
+
+            -- Bobbing motion
+            local groundY = TerrainUtils.getGroundY(particle.Position.X, particle.Position.Z)
+            particle.Position = Vector3.new(
+                particle.Position.X,
+                groundY + 2 + math.sin(phase) * 0.5,
+                particle.Position.Z
+            )
+        end
+    end
+end
+
+--[[
+    Fade out path particles.
+]]
+local function fadePathParticles()
+    for _, particle in ipairs(pathParticles) do
+        if particle and particle.Parent then
+            local tween = TweenService:Create(particle, FADE_TWEEN_INFO, {
+                Transparency = 1,
+            })
+            tween:Play()
+
+            local light = particle:FindFirstChild("ParticleLight") :: PointLight?
+            if light then
+                local lightTween = TweenService:Create(light, FADE_TWEEN_INFO, {
+                    Brightness = 0,
+                })
+                lightTween:Play()
+            end
+        end
+    end
+
+    tutorialState.pathShown = false
+    print("[Tutorial] Path particles fading")
+end
+
+--[[
+    Create a floating hint billboard above a control.
+]]
+local function createHintBillboard(x: number, z: number, stationName: string): BillboardGui
+    local groundY = TerrainUtils.getGroundY(x, z)
+
+    -- Create anchor part
+    local anchor = Instance.new("Part")
+    anchor.Name = stationName .. "_HintAnchor"
+    anchor.Size = Vector3.new(1, 1, 1)
+    anchor.Position = Vector3.new(x, groundY + 12, z)
+    anchor.Anchored = true
+    anchor.Transparency = 1
+    anchor.CanCollide = false
+    anchor.Parent = tutorialFolder
+
+    -- Create billboard
+    local billboard = Instance.new("BillboardGui")
+    billboard.Name = stationName .. "_Hint"
+    billboard.Size = UDim2.new(0, 250, 0, 100)
+    billboard.StudsOffset = Vector3.new(0, 0, 0)
+    billboard.Adornee = anchor
+    billboard.AlwaysOnTop = true
+    billboard.Parent = anchor
+
+    -- Background frame
+    local frame = Instance.new("Frame")
+    frame.Name = "Background"
+    frame.Size = UDim2.new(1, 0, 1, 0)
+    frame.BackgroundColor3 = Color3.fromRGB(30, 30, 40)
+    frame.BackgroundTransparency = 0.3
+    frame.BorderSizePixel = 0
+    frame.Parent = billboard
+
+    local corner = Instance.new("UICorner")
+    corner.CornerRadius = UDim.new(0, 8)
+    corner.Parent = frame
+
+    -- Hint text
+    local hintLabel = Instance.new("TextLabel")
+    hintLabel.Name = "HintText"
+    hintLabel.Size = UDim2.new(1, -10, 0.5, 0)
+    hintLabel.Position = UDim2.new(0, 5, 0, 5)
+    hintLabel.BackgroundTransparency = 1
+    hintLabel.Text = "Stand on plates to control"
+    hintLabel.TextColor3 = AssetConfig.Tutorial.HintColor
+    hintLabel.TextSize = 14
+    hintLabel.Font = Enum.Font.GothamBold
+    hintLabel.TextXAlignment = Enum.TextXAlignment.Center
+    hintLabel.Parent = frame
+
+    -- Instruction text
+    local instructionLabel = Instance.new("TextLabel")
+    instructionLabel.Name = "InstructionText"
+    instructionLabel.Size = UDim2.new(1, -10, 0.5, 0)
+    instructionLabel.Position = UDim2.new(0, 5, 0.5, 0)
+    instructionLabel.BackgroundTransparency = 1
+    instructionLabel.Text = "GREEN = Increase | RED = Decrease"
+    instructionLabel.TextColor3 = Color3.fromRGB(200, 200, 200)
+    instructionLabel.TextSize = 12
+    instructionLabel.Font = Enum.Font.Gotham
+    instructionLabel.TextXAlignment = Enum.TextXAlignment.Center
+    instructionLabel.Parent = frame
+
+    -- Glowing border
+    local stroke = Instance.new("UIStroke")
+    stroke.Color = AssetConfig.Tutorial.GlowColor
+    stroke.Thickness = 2
+    stroke.Transparency = 0.3
+    stroke.Parent = frame
+
+    table.insert(hintBillboards, billboard)
+
+    return billboard
+end
+
+--[[
+    Create hint billboards for all control stations.
+]]
+local function createAllHints()
+    if not tutorialFolder then
+        return
+    end
+
+    for _, station in pairs(STATION_LOCATIONS) do
+        createHintBillboard(station.x, station.z, station.name)
+    end
+
+    print(string.format("[Tutorial] Created %d hint billboards", #hintBillboards))
+end
+
+--[[
+    Fade out all hint billboards.
+]]
+local function fadeAllHints()
+    for _, billboard in ipairs(hintBillboards) do
+        if billboard and billboard.Parent then
+            local frame = billboard:FindFirstChild("Background") :: Frame?
+            if frame then
+                local tween = TweenService:Create(frame, FADE_TWEEN_INFO, {
+                    BackgroundTransparency = 1,
+                })
+                tween:Play()
+
+                for _, child in ipairs(frame:GetChildren()) do
+                    if child:IsA("TextLabel") then
+                        local textTween = TweenService:Create(child, FADE_TWEEN_INFO, {
+                            TextTransparency = 1,
+                        })
+                        textTween:Play()
+                    elseif child:IsA("UIStroke") then
+                        local strokeTween = TweenService:Create(child, FADE_TWEEN_INFO, {
+                            Transparency = 1,
+                        })
+                        strokeTween:Play()
+                    end
+                end
+            end
+        end
+    end
+
+    tutorialState.hintsVisible = false
+    print("[Tutorial] All hints fading")
+end
+
+--[[
+    Check if all controls have been used.
+]]
+local function allControlsUsed(): boolean
+    for _, used in pairs(tutorialState.controlsUsed) do
+        if not used then
+            return false
+        end
+    end
+    return true
+end
+
+--[[
+    Check if player is near Forum (to fade path).
+]]
+local function checkPlayerNearForum()
+    local character = localPlayer.Character
+    if not character then
+        return
+    end
+
+    local humanoidRootPart = character:FindFirstChild("HumanoidRootPart") :: BasePart?
+    if not humanoidRootPart then
+        return
+    end
+
+    local pos = humanoidRootPart.Position
+    local forumX = STATION_LOCATIONS.forum.x
+    local forumZ = STATION_LOCATIONS.forum.z
+
+    local distance = math.sqrt((pos.X - forumX) ^ 2 + (pos.Z - forumZ) ^ 2)
+
+    if distance < 20 and tutorialState.pathShown then
+        fadePathParticles()
+    end
+end
+
+--[[
+    Handle control input events.
+]]
+ControlInputEvent.OnClientEvent:Connect(function(controlType: string, isActivating: boolean)
+    if isActivating then
+        -- Mark this control as used
+        tutorialState.controlsUsed[controlType] = true
+
+        print(string.format("[Tutorial] Control used: %s", controlType))
+
+        -- Check if all controls used - fade all hints
+        if allControlsUsed() and tutorialState.hintsVisible then
+            fadeAllHints()
+        end
+    end
+end)
+
+-- Initialize tutorial folder
+tutorialFolder = Instance.new("Folder")
+tutorialFolder.Name = "Tutorial"
+tutorialFolder.Parent = workspace
+
+-- Wait for terrain and controls
+task.wait(10)
+
+-- Create tutorial elements
+createPathToForum()
+createAllHints()
+
+-- Animation loop for path particles
+RunService.Heartbeat:Connect(function(dt: number)
+    if tutorialState.pathShown then
+        animatePathParticles(dt)
+        checkPlayerNearForum()
+    end
+end)
+
+print("")
+print("Tutorial system running!")
+print("  Glowing path leads to Forum")
+print("  Hint billboards above each control")
+print("  Hints fade after controls are used")

--- a/roblox/rome-assets/rome-game/src/server/AssetPlacer.server.luau
+++ b/roblox/rome-assets/rome-game/src/server/AssetPlacer.server.luau
@@ -1,0 +1,353 @@
+--!strict
+--[[
+    AssetPlacer.server.luau
+
+    Places Roman building 3D models in the environment using mesh asset IDs.
+
+    Features:
+    - Loads 3D meshes from Roblox asset library
+    - Places buildings at appropriate flat zones
+    - Creates placeholder Parts if mesh loading fails
+    - Uses TerrainUtils for proper ground placement
+
+    Buildings Placed:
+    - Colosseum at Colosseum zone
+    - Pantheon at Forum
+    - Temple at Temple District
+    - Columns in rows at Forum
+    - Market stalls at Market zone
+    - Aqueduct chain across terrain
+]]
+
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+-- Wait for terrain to generate before placing assets
+task.wait(6)
+
+-- Wait for shared modules
+local Shared = ReplicatedStorage:WaitForChild("Shared")
+local TerrainUtils = require(Shared:WaitForChild("TerrainUtils"))
+local AssetConfig = require(Shared:WaitForChild("AssetConfig"))
+local TerrainGenerator = require(Shared:WaitForChild("TerrainGenerator"))
+
+print("==============================================")
+print("  ASSET PLACER INITIALIZING")
+print("==============================================")
+print("")
+
+-- Create a folder to hold all placed assets
+local assetsFolder = Instance.new("Folder")
+assetsFolder.Name = "RomanBuildings"
+assetsFolder.Parent = workspace
+
+-- Get flat zones from terrain generator
+local flatZones = TerrainGenerator.getFlatZones()
+
+--[[
+    Find a flat zone by name.
+]]
+local function findZone(name: string): { centerX: number, centerZ: number, radiusX: number, radiusZ: number, elevation: number }?
+    for _, zone in ipairs(flatZones) do
+        if zone.name == name then
+            return zone
+        end
+    end
+    return nil
+end
+
+--[[
+    Create a MeshPart with the specified mesh ID.
+    Returns the created part or nil if creation fails.
+]]
+local function createMeshPart(name: string, meshId: string, scale: Vector3, color: Color3): MeshPart
+    local meshPart = Instance.new("MeshPart")
+    meshPart.Name = name
+    meshPart.Size = scale
+    meshPart.MeshId = meshId
+    meshPart.Color = color
+    meshPart.Material = Enum.Material.Limestone
+    meshPart.Anchored = true
+    meshPart.CanCollide = true
+    meshPart.CastShadow = true
+
+    return meshPart
+end
+
+--[[
+    Create a placeholder Part when mesh loading fails.
+]]
+local function createPlaceholder(name: string, size: Vector3, color: Color3): Part
+    local part = Instance.new("Part")
+    part.Name = name .. "_Placeholder"
+    part.Size = size
+    part.Color = color
+    part.Material = Enum.Material.Limestone
+    part.Anchored = true
+    part.CanCollide = true
+    part.CastShadow = true
+
+    -- Add a label to indicate placeholder
+    local billboard = Instance.new("BillboardGui")
+    billboard.Size = UDim2.new(0, 100, 0, 30)
+    billboard.StudsOffset = Vector3.new(0, size.Y / 2 + 5, 0)
+    billboard.AlwaysOnTop = false
+
+    local label = Instance.new("TextLabel")
+    label.Size = UDim2.new(1, 0, 1, 0)
+    label.BackgroundTransparency = 1
+    label.Text = name
+    label.TextColor3 = Color3.new(1, 1, 1)
+    label.TextStrokeTransparency = 0.5
+    label.Font = Enum.Font.GothamBold
+    label.TextScaled = true
+    label.Parent = billboard
+
+    billboard.Parent = part
+
+    return part
+end
+
+--[[
+    Place a building at the specified position using TerrainUtils.
+]]
+local function placeBuilding(
+    name: string,
+    meshId: string,
+    x: number,
+    z: number,
+    scale: Vector3,
+    color: Color3,
+    rotation: number?
+): BasePart
+    local rot = rotation or 0
+    local groundY = TerrainUtils.getGroundY(x, z)
+
+    local building: BasePart
+
+    -- Try to create mesh part
+    local success, result = pcall(function()
+        return createMeshPart(name, meshId, scale, color)
+    end)
+
+    if success and result then
+        building = result
+    else
+        warn(string.format("[AssetPlacer] Mesh failed for %s, using placeholder", name))
+        building = createPlaceholder(name, scale, color)
+    end
+
+    -- Position the building
+    local yOffset = scale.Y / 2
+    building.CFrame = CFrame.new(x, groundY + yOffset, z) * CFrame.Angles(0, math.rad(rot), 0)
+    building.Parent = assetsFolder
+
+    print(string.format("[AssetPlacer] Placed %s at (%.0f, %.1f, %.0f)", name, x, groundY, z))
+
+    return building
+end
+
+--[[
+    Place the Colosseum at its designated zone.
+]]
+local function placeColosseum()
+    local zone = findZone("Colosseum")
+    if not zone then
+        warn("[AssetPlacer] Colosseum zone not found")
+        return
+    end
+
+    local config = AssetConfig.Placements.Colosseum
+    placeBuilding(
+        "Colosseum",
+        AssetConfig.Meshes.Colosseum,
+        zone.centerX,
+        zone.centerZ,
+        config.scale,
+        AssetConfig.Colors.Limestone,
+        config.rotation
+    )
+end
+
+--[[
+    Place the Pantheon at the Forum.
+]]
+local function placePantheon()
+    local zone = findZone("Forum")
+    if not zone then
+        warn("[AssetPlacer] Forum zone not found")
+        return
+    end
+
+    -- Place Pantheon offset from center to not overlap with control plates
+    local config = AssetConfig.Placements.Pantheon
+    placeBuilding(
+        "Pantheon",
+        AssetConfig.Meshes.Pantheon,
+        zone.centerX - 30,
+        zone.centerZ + 20,
+        config.scale,
+        AssetConfig.Colors.Marble,
+        config.rotation
+    )
+end
+
+--[[
+    Place the Temple at Temple District.
+]]
+local function placeTemple()
+    local zone = findZone("Temple District")
+    if not zone then
+        warn("[AssetPlacer] Temple District zone not found")
+        return
+    end
+
+    -- Place temple offset from control plates
+    local config = AssetConfig.Placements.RomanTemple
+    placeBuilding(
+        "RomanTemple",
+        AssetConfig.Meshes.RomanTemple,
+        zone.centerX + 20,
+        zone.centerZ - 15,
+        config.scale,
+        AssetConfig.Colors.Marble,
+        config.rotation
+    )
+end
+
+--[[
+    Place a Triumphal Arch near the Forum entrance.
+]]
+local function placeTriumphalArch()
+    local zone = findZone("Forum")
+    if not zone then
+        return
+    end
+
+    local config = AssetConfig.Placements.TriumphalArch
+    placeBuilding(
+        "TriumphalArch",
+        AssetConfig.Meshes.TriumphalArch,
+        zone.centerX + 40,
+        zone.centerZ - 25,
+        config.scale,
+        AssetConfig.Colors.Limestone,
+        config.rotation
+    )
+end
+
+--[[
+    Place rows of columns in the Forum area.
+]]
+local function placeColumns()
+    local zone = findZone("Forum")
+    if not zone then
+        return
+    end
+
+    local config = AssetConfig.Placements.DoricColumn
+    local columnSpacing = 8
+    local rowOffset = 15
+
+    -- Two rows of columns along the Forum
+    for row = 1, 2 do
+        local rowZ = zone.centerZ + (row == 1 and -rowOffset or rowOffset)
+
+        for i = 1, 5 do
+            local colX = zone.centerX + 15 + (i - 1) * columnSpacing
+            placeBuilding(
+                "DoricColumn_" .. row .. "_" .. i,
+                AssetConfig.Meshes.DoricColumn,
+                colX,
+                rowZ,
+                config.scale,
+                AssetConfig.Colors.Marble,
+                0
+            )
+        end
+    end
+end
+
+--[[
+    Place market stalls in the Market zone.
+]]
+local function placeMarketStalls()
+    local zone = findZone("Market")
+    if not zone then
+        warn("[AssetPlacer] Market zone not found")
+        return
+    end
+
+    local config = AssetConfig.Placements.MarketStall
+    local stallPositions = {
+        { x = zone.centerX - 15, z = zone.centerZ - 20, rot = 0 },
+        { x = zone.centerX + 15, z = zone.centerZ - 20, rot = 0 },
+        { x = zone.centerX - 15, z = zone.centerZ + 10, rot = 180 },
+        { x = zone.centerX + 15, z = zone.centerZ + 10, rot = 180 },
+        { x = zone.centerX - 25, z = zone.centerZ - 5, rot = 90 },
+        { x = zone.centerX + 25, z = zone.centerZ - 5, rot = 270 },
+    }
+
+    for i, pos in ipairs(stallPositions) do
+        placeBuilding(
+            "MarketStall_" .. i,
+            AssetConfig.Meshes.MarketStall,
+            pos.x,
+            pos.z,
+            config.scale,
+            AssetConfig.Colors.Wood,
+            pos.rot
+        )
+    end
+end
+
+--[[
+    Place aqueduct segments across the terrain.
+]]
+local function placeAqueduct()
+    local config = AssetConfig.Placements.RomanAqueduct
+    local segmentSpacing = 25
+    local startX = -150
+    local startZ = 160 -- North of the main areas, near river
+
+    -- Create 5 aqueduct segments in a line
+    for i = 1, 5 do
+        local x = startX + (i - 1) * segmentSpacing
+        local z = startZ + math.sin(i * 0.3) * 10 -- Slight curve
+
+        placeBuilding(
+            "Aqueduct_" .. i,
+            AssetConfig.Meshes.RomanAqueduct,
+            x,
+            z,
+            config.scale,
+            AssetConfig.Colors.Limestone,
+            75 -- Angle across terrain
+        )
+    end
+end
+
+-- Place all buildings
+print("Placing Roman buildings...")
+print("")
+
+placeColosseum()
+placePantheon()
+placeTemple()
+placeTriumphalArch()
+placeColumns()
+placeMarketStalls()
+placeAqueduct()
+
+print("")
+print("==============================================")
+print("  ASSET PLACEMENT COMPLETE")
+print("==============================================")
+print("")
+print("Placed buildings:")
+print("  - Colosseum")
+print("  - Pantheon")
+print("  - Roman Temple")
+print("  - Triumphal Arch")
+print("  - 10 Doric Columns")
+print("  - 6 Market Stalls")
+print("  - 5 Aqueduct Segments")

--- a/roblox/rome-assets/rome-game/src/server/Controls.server.luau
+++ b/roblox/rome-assets/rome-game/src/server/Controls.server.luau
@@ -3,18 +3,27 @@
     Controls.server.luau
 
     Creates pressure plate controls for player interaction with SDT parameters.
+    Themed with Roman administrative systems for immersive gameplay.
 
     Features:
     - 4 control stations placed at key Roman locations
     - Each station has paired red/green plates for bidirectional control
     - Gradual parameter adjustment while standing on plate
     - Visual and audio feedback
+    - Roman-themed names with descriptive floating text
 
-    Control Stations:
-    1. PSI Control (Forum) - Direct PSI adjustment for testing
-    2. Senate Seats (Near Forum) - Controls elite recruitment rate (alpha)
-    3. Grain Dole (Market) - Controls wage recovery rate (gamma)
-    4. Legion Funding (Temple District) - Controls state spending/recovery (delta)
+    Control Stations (Roman Themed):
+    1. POLITICAL STRESS (Forum) - Direct PSI adjustment for testing
+       "Control public unrest through spectacles and speeches"
+
+    2. SENATE SEATS (Near Forum) - Controls elite recruitment rate (alpha)
+       "Expand or restrict access to the Senatorial class"
+
+    3. GRAIN DOLE (Market) - Controls wage recovery rate (gamma)
+       "The bread that feeds Rome's hungry masses"
+
+    4. TAX COLLECTORS (Temple District) - Controls state income/recovery (delta)
+       "Fund the legions or let the treasury empty"
 ]]
 
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
@@ -310,10 +319,10 @@ createControlStation(
     STATION_LOCATIONS.forum.z,
     "decrease_psi",
     "increase_psi",
-    "DECREASE STRESS",
-    "INCREASE STRESS",
+    "CALM THE MOB",
+    "ROUSE THE MOB",
     "POLITICAL STRESS",
-    "Direct PSI Control"
+    "Control public unrest through spectacles and speeches"
 )
 
 -- Station 2: Senate Seats (Elite Recruitment - alpha)
@@ -326,7 +335,7 @@ createControlStation(
     "FEWER SEATS",
     "MORE SEATS",
     "SENATE SEATS",
-    "Elite Recruitment Rate"
+    "Expand or restrict access to the Senatorial class"
 )
 
 -- Station 3: Grain Dole (Wage Recovery - gamma)
@@ -339,20 +348,20 @@ createControlStation(
     "REDUCE DOLE",
     "INCREASE DOLE",
     "GRAIN DOLE",
-    "Worker Wage Recovery"
+    "The bread that feeds Rome's hungry masses"
 )
 
--- Station 4: Legion Funding (State Recovery - delta)
+-- Station 4: Tax Collectors (State Recovery - delta)
 createControlStation(
-    "Legion",
+    "TaxCollectors",
     STATION_LOCATIONS.templeDistrict.x,
     STATION_LOCATIONS.templeDistrict.z,
     "decrease_delta",
     "increase_delta",
-    "CUT FUNDING",
-    "RAISE FUNDING",
-    "LEGION FUNDING",
-    "State Fiscal Recovery"
+    "REDUCE TAXES",
+    "RAISE TAXES",
+    "TAX COLLECTORS",
+    "Fund the legions or let the treasury empty"
 )
 
 -- Polling loop to detect players on plates
@@ -451,10 +460,11 @@ print("==============================================")
 print("  CONTROL STATIONS READY")
 print("==============================================")
 print("")
-print("4 Control Stations:")
-print("  1. Political Stress (Forum) - Direct PSI control")
+print("4 Roman Control Stations:")
+print("  1. Political Stress (Forum) - Control public unrest")
 print("  2. Senate Seats (Near Forum) - Elite recruitment rate")
-print("  3. Grain Dole (Market) - Wage recovery rate")
-print("  4. Legion Funding (Temple) - State fiscal recovery")
+print("  3. Grain Dole (Market) - Worker wage recovery")
+print("  4. Tax Collectors (Temple) - State fiscal recovery")
 print("")
 print("Stand on plates to adjust parameters (~0.05/second)")
+print("Green = Increase, Red = Decrease")

--- a/roblox/rome-assets/rome-game/src/server/ProceduralBuildings.server.luau
+++ b/roblox/rome-assets/rome-game/src/server/ProceduralBuildings.server.luau
@@ -1,0 +1,359 @@
+--!strict
+--[[
+    ProceduralBuildings.server.luau
+
+    Generates procedural Part-based buildings for residential areas.
+
+    Features:
+    - Insulae (Roman apartment blocks) - stacked colored Parts with doorways
+    - Small shops - open-front structures
+    - Colorful, enterable buildings (no blocked doorways)
+    - Placed in residential zones using TerrainUtils
+
+    Building Types:
+    - Insulae: 2-4 story apartment blocks with windows and doors
+    - Shops: Single-story open-front structures with awnings
+]]
+
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+-- Wait for terrain to generate
+task.wait(7)
+
+-- Wait for shared modules
+local Shared = ReplicatedStorage:WaitForChild("Shared")
+local TerrainUtils = require(Shared:WaitForChild("TerrainUtils"))
+local TerrainGenerator = require(Shared:WaitForChild("TerrainGenerator"))
+
+print("==============================================")
+print("  PROCEDURAL BUILDINGS GENERATOR")
+print("==============================================")
+print("")
+
+-- Create folder for procedural buildings
+local buildingsFolder = Instance.new("Folder")
+buildingsFolder.Name = "ProceduralBuildings"
+buildingsFolder.Parent = workspace
+
+-- Building colors (warm Mediterranean palette)
+local BUILDING_COLORS = {
+    Color3.fromRGB(240, 220, 180), -- Cream
+    Color3.fromRGB(255, 200, 150), -- Peach
+    Color3.fromRGB(230, 180, 140), -- Terracotta light
+    Color3.fromRGB(200, 170, 130), -- Tan
+    Color3.fromRGB(220, 200, 160), -- Beige
+    Color3.fromRGB(250, 230, 200), -- Off-white
+}
+
+local ROOF_COLORS = {
+    Color3.fromRGB(180, 80, 60), -- Red tile
+    Color3.fromRGB(160, 70, 50), -- Dark red tile
+    Color3.fromRGB(170, 90, 70), -- Rust
+}
+
+local DOOR_COLOR = Color3.fromRGB(100, 70, 40) -- Dark wood
+local WINDOW_COLOR = Color3.fromRGB(60, 80, 100) -- Dark blue (shuttered)
+local AWNING_COLORS = {
+    Color3.fromRGB(180, 60, 40), -- Red
+    Color3.fromRGB(60, 100, 140), -- Blue
+    Color3.fromRGB(80, 120, 60), -- Green
+    Color3.fromRGB(180, 140, 60), -- Gold
+}
+
+-- Random seed for consistency
+local rng = Random.new(753) -- Rome founding year seed
+
+-- Get flat zones
+local flatZones = TerrainGenerator.getFlatZones()
+
+--[[
+    Find zones by partial name match.
+]]
+local function findZonesByName(pattern: string): { any }
+    local matches = {}
+    for _, zone in ipairs(flatZones) do
+        if string.find(zone.name:lower(), pattern:lower()) then
+            table.insert(matches, zone)
+        end
+    end
+    return matches
+end
+
+--[[
+    Pick a random color from a list.
+]]
+local function randomColor(colors: { Color3 }): Color3
+    return colors[rng:NextInteger(1, #colors)]
+end
+
+--[[
+    Create a basic Part with standard properties.
+]]
+local function createPart(name: string, size: Vector3, color: Color3, material: Enum.Material?): Part
+    local part = Instance.new("Part")
+    part.Name = name
+    part.Size = size
+    part.Color = color
+    part.Material = material or Enum.Material.Brick
+    part.Anchored = true
+    part.CanCollide = true
+    part.CastShadow = true
+    part.TopSurface = Enum.SurfaceType.Smooth
+    part.BottomSurface = Enum.SurfaceType.Smooth
+    return part
+end
+
+--[[
+    Create an Insula (Roman apartment block).
+
+    Structure:
+    - 2-4 stories high
+    - Main wall sections with window/door cutouts
+    - Flat or sloped roof
+    - Ground floor doorway for entry
+]]
+local function createInsula(x: number, z: number, rotation: number): Model
+    local model = Instance.new("Model")
+    model.Name = "Insula"
+
+    local stories = rng:NextInteger(2, 4)
+    local width = rng:NextNumber(12, 18)
+    local depth = rng:NextNumber(10, 14)
+    local storyHeight = 4
+    local wallThickness = 0.5
+
+    local buildingColor = randomColor(BUILDING_COLORS)
+    local roofColor = randomColor(ROOF_COLORS)
+
+    local groundY = TerrainUtils.getGroundY(x, z)
+    local totalHeight = stories * storyHeight
+
+    -- Create main walls
+    -- Front wall (with door)
+    local frontWall = createPart("FrontWall", Vector3.new(width, totalHeight, wallThickness), buildingColor)
+    frontWall.CFrame = CFrame.new(0, totalHeight / 2, -depth / 2)
+    frontWall.Parent = model
+
+    -- Back wall
+    local backWall = createPart("BackWall", Vector3.new(width, totalHeight, wallThickness), buildingColor)
+    backWall.CFrame = CFrame.new(0, totalHeight / 2, depth / 2)
+    backWall.Parent = model
+
+    -- Left wall
+    local leftWall = createPart("LeftWall", Vector3.new(wallThickness, totalHeight, depth), buildingColor)
+    leftWall.CFrame = CFrame.new(-width / 2, totalHeight / 2, 0)
+    leftWall.Parent = model
+
+    -- Right wall
+    local rightWall = createPart("RightWall", Vector3.new(wallThickness, totalHeight, depth), buildingColor)
+    rightWall.CFrame = CFrame.new(width / 2, totalHeight / 2, 0)
+    rightWall.Parent = model
+
+    -- Floor/ceiling for each story
+    for story = 0, stories do
+        local floorY = story * storyHeight
+        local floor = createPart("Floor_" .. story, Vector3.new(width - wallThickness, 0.3, depth - wallThickness), buildingColor)
+        floor.CFrame = CFrame.new(0, floorY + 0.15, 0)
+        floor.Parent = model
+    end
+
+    -- Roof
+    local roof = createPart("Roof", Vector3.new(width + 1, 0.5, depth + 1), roofColor, Enum.Material.Slate)
+    roof.CFrame = CFrame.new(0, totalHeight + 0.25, 0)
+    roof.Parent = model
+
+    -- Door (opening in front wall)
+    local doorWidth = 2.5
+    local doorHeight = 3
+    local door = createPart("Door", Vector3.new(doorWidth, doorHeight, wallThickness + 0.1), DOOR_COLOR, Enum.Material.Wood)
+    door.CFrame = CFrame.new(0, doorHeight / 2, -depth / 2 - 0.05)
+    door.Transparency = 0.3 -- Semi-transparent for "open" feel
+    door.CanCollide = false -- Walkthrough
+    door.Parent = model
+
+    -- Windows for each upper story
+    local windowSize = Vector3.new(1.5, 2, 0.2)
+    for story = 2, stories do
+        local windowY = (story - 1) * storyHeight + storyHeight / 2
+
+        -- Front windows
+        for wx = -1, 1, 2 do
+            local windowX = wx * (width / 4)
+            local window = createPart("Window_Front_" .. story .. "_" .. wx, windowSize, WINDOW_COLOR, Enum.Material.Glass)
+            window.CFrame = CFrame.new(windowX, windowY, -depth / 2 - 0.1)
+            window.Parent = model
+        end
+    end
+
+    -- Position the entire model
+    local primaryPart = frontWall
+    model.PrimaryPart = primaryPart
+    model:SetPrimaryPartCFrame(
+        CFrame.new(x, groundY + totalHeight / 2, z) * CFrame.Angles(0, math.rad(rotation), 0)
+    )
+
+    return model
+end
+
+--[[
+    Create a small shop structure.
+
+    Structure:
+    - Single story with open front
+    - Counter at front
+    - Colorful awning
+]]
+local function createShop(x: number, z: number, rotation: number): Model
+    local model = Instance.new("Model")
+    model.Name = "Shop"
+
+    local width = rng:NextNumber(6, 10)
+    local depth = rng:NextNumber(5, 8)
+    local height = 3.5
+    local wallThickness = 0.4
+
+    local buildingColor = randomColor(BUILDING_COLORS)
+    local awningColor = randomColor(AWNING_COLORS)
+
+    local groundY = TerrainUtils.getGroundY(x, z)
+
+    -- Back wall
+    local backWall = createPart("BackWall", Vector3.new(width, height, wallThickness), buildingColor)
+    backWall.CFrame = CFrame.new(0, height / 2, depth / 2)
+    backWall.Parent = model
+
+    -- Left wall
+    local leftWall = createPart("LeftWall", Vector3.new(wallThickness, height, depth), buildingColor)
+    leftWall.CFrame = CFrame.new(-width / 2, height / 2, 0)
+    leftWall.Parent = model
+
+    -- Right wall
+    local rightWall = createPart("RightWall", Vector3.new(wallThickness, height, depth), buildingColor)
+    rightWall.CFrame = CFrame.new(width / 2, height / 2, 0)
+    rightWall.Parent = model
+
+    -- Floor
+    local floor = createPart("Floor", Vector3.new(width, 0.3, depth), buildingColor)
+    floor.CFrame = CFrame.new(0, 0.15, 0)
+    floor.Parent = model
+
+    -- Roof
+    local roof = createPart("Roof", Vector3.new(width + 0.5, 0.4, depth + 0.5), randomColor(ROOF_COLORS), Enum.Material.Slate)
+    roof.CFrame = CFrame.new(0, height + 0.2, 0)
+    roof.Parent = model
+
+    -- Counter at front
+    local counter = createPart("Counter", Vector3.new(width - 0.5, 1, 0.6), Color3.fromRGB(120, 80, 50), Enum.Material.Wood)
+    counter.CFrame = CFrame.new(0, 0.5, -depth / 2 + 0.3)
+    counter.Parent = model
+
+    -- Awning over front
+    local awning = createPart("Awning", Vector3.new(width + 1, 0.2, 2), awningColor, Enum.Material.Fabric)
+    awning.CFrame = CFrame.new(0, height - 0.3, -depth / 2 - 0.8) * CFrame.Angles(math.rad(15), 0, 0)
+    awning.Parent = model
+
+    -- Position the entire model
+    model.PrimaryPart = backWall
+    model:SetPrimaryPartCFrame(
+        CFrame.new(x, groundY + height / 2, z) * CFrame.Angles(0, math.rad(rotation), 0)
+    )
+
+    return model
+end
+
+--[[
+    Generate buildings in a residential zone.
+]]
+local function populateResidentialZone(zone: any)
+    print(string.format("[ProceduralBuildings] Populating %s", zone.name))
+
+    local centerX = zone.centerX
+    local centerZ = zone.centerZ
+    local radiusX = zone.radiusX * 0.7 -- Stay within zone
+    local radiusZ = zone.radiusZ * 0.7
+
+    local buildingCount = 0
+
+    -- Grid of buildings with some randomness
+    local gridSpacing = 20
+    local positions: { { x: number, z: number, rot: number } } = {}
+
+    -- Generate positions in a grid pattern
+    for gx = -1, 1 do
+        for gz = -1, 1 do
+            if gx == 0 and gz == 0 then
+                continue -- Leave center open
+            end
+
+            local x = centerX + gx * gridSpacing + rng:NextNumber(-3, 3)
+            local z = centerZ + gz * gridSpacing + rng:NextNumber(-3, 3)
+
+            -- Check if within zone bounds
+            local dx = math.abs(x - centerX) / radiusX
+            local dz = math.abs(z - centerZ) / radiusZ
+            if dx * dx + dz * dz < 1 then
+                local rotation = rng:NextInteger(0, 3) * 90
+                table.insert(positions, { x = x, z = z, rot = rotation })
+            end
+        end
+    end
+
+    -- Create buildings at positions
+    for _, pos in ipairs(positions) do
+        local building: Model
+
+        -- 70% insulae, 30% shops
+        if rng:NextNumber() < 0.7 then
+            building = createInsula(pos.x, pos.z, pos.rot)
+        else
+            building = createShop(pos.x, pos.z, pos.rot)
+        end
+
+        building.Parent = buildingsFolder
+        buildingCount = buildingCount + 1
+    end
+
+    print(string.format("  Created %d buildings in %s", buildingCount, zone.name))
+end
+
+-- Find and populate residential zones
+local residentialZones = findZonesByName("Residential")
+
+print(string.format("Found %d residential zones", #residentialZones))
+print("")
+
+for _, zone in ipairs(residentialZones) do
+    populateResidentialZone(zone)
+end
+
+-- Also add some buildings near Palatine Hill (wealthy area)
+local palatineZone = nil
+for _, zone in ipairs(flatZones) do
+    if zone.name == "Palatine Hill" then
+        palatineZone = zone
+        break
+    end
+end
+
+if palatineZone then
+    print("Adding villas to Palatine Hill...")
+
+    -- Add a few larger insulae (wealthy apartments)
+    for i = 1, 3 do
+        local angle = (i - 1) * 120
+        local dist = 20
+        local x = palatineZone.centerX + math.cos(math.rad(angle)) * dist
+        local z = palatineZone.centerZ + math.sin(math.rad(angle)) * dist
+
+        local villa = createInsula(x, z, angle + 180)
+        villa.Name = "Villa_" .. i
+        villa.Parent = buildingsFolder
+    end
+
+    print("  Created 3 villas on Palatine Hill")
+end
+
+print("")
+print("==============================================")
+print("  PROCEDURAL BUILDINGS COMPLETE")
+print("==============================================")

--- a/roblox/rome-assets/rome-game/src/shared/AssetConfig.luau
+++ b/roblox/rome-assets/rome-game/src/shared/AssetConfig.luau
@@ -1,0 +1,107 @@
+--!strict
+--[[
+    AssetConfig.luau
+
+    Configuration module containing all 3D model asset IDs for Roman buildings.
+    These are mesh asset IDs from the Roblox library.
+
+    Usage:
+        local AssetConfig = require(path.to.AssetConfig)
+        local meshId = AssetConfig.Meshes.Colosseum
+]]
+
+local AssetConfig = {}
+
+-- Mesh Asset IDs
+AssetConfig.Meshes = {
+    Colosseum = "rbxassetid://126740068391615",
+    Pantheon = "rbxassetid://99309794928903",
+    RomanTemple = "rbxassetid://119800018358438",
+    TriumphalArch = "rbxassetid://80950297053943",
+    RomanAqueduct = "rbxassetid://120006200986942",
+    DoricColumn = "rbxassetid://99822185467408",
+    MarketStall = "rbxassetid://82241393018988",
+}
+
+-- Default materials for buildings
+AssetConfig.Materials = {
+    Stone = Enum.Material.Limestone,
+    Marble = Enum.Material.Marble,
+    Wood = Enum.Material.Wood,
+    Bronze = Enum.Material.Metal,
+}
+
+-- Default colors
+AssetConfig.Colors = {
+    Marble = Color3.fromRGB(245, 240, 230),
+    Limestone = Color3.fromRGB(220, 210, 190),
+    Sandstone = Color3.fromRGB(210, 180, 140),
+    Bronze = Color3.fromRGB(180, 140, 90),
+    WornStone = Color3.fromRGB(180, 175, 165),
+    Wood = Color3.fromRGB(140, 100, 60),
+    RedTile = Color3.fromRGB(180, 80, 60),
+}
+
+-- Building placement configurations
+AssetConfig.Placements = {
+    Colosseum = {
+        scale = Vector3.new(15, 15, 15),
+        rotation = 0,
+        yOffset = 0,
+    },
+    Pantheon = {
+        scale = Vector3.new(12, 12, 12),
+        rotation = 180,
+        yOffset = 0,
+    },
+    RomanTemple = {
+        scale = Vector3.new(8, 8, 8),
+        rotation = 0,
+        yOffset = 0,
+    },
+    TriumphalArch = {
+        scale = Vector3.new(6, 6, 6),
+        rotation = 90,
+        yOffset = 0,
+    },
+    RomanAqueduct = {
+        scale = Vector3.new(10, 10, 10),
+        rotation = 0,
+        yOffset = 0,
+    },
+    DoricColumn = {
+        scale = Vector3.new(3, 3, 3),
+        rotation = 0,
+        yOffset = 0,
+    },
+    MarketStall = {
+        scale = Vector3.new(4, 4, 4),
+        rotation = 0,
+        yOffset = 0,
+    },
+}
+
+-- Sound Asset IDs (Roblox default sounds)
+AssetConfig.Sounds = {
+    -- UI/Interaction
+    PlateStep = "rbxassetid://6042053626", -- UI click
+    PlateActivate = "rbxassetid://421058925", -- Soft chime
+
+    -- Ambient
+    CrowdMurmur = "rbxassetid://9116367423", -- Crowd ambient
+    Birds = "rbxassetid://9116367423", -- Bird chirps
+    Wind = "rbxassetid://9114082060", -- Wind ambient
+
+    -- Effects
+    Footstep = "rbxassetid://5892287796", -- Stone footstep
+}
+
+-- Tutorial hint configurations
+AssetConfig.Tutorial = {
+    HintColor = Color3.fromRGB(255, 255, 150),
+    GlowColor = Color3.fromRGB(100, 255, 100),
+    PathParticleColor = Color3.fromRGB(255, 220, 100),
+    FadeDuration = 2.0,
+}
+
+return AssetConfig


### PR DESCRIPTION
## Summary

Transform the Phase 1 technical prototype into an immersive Rome environment with:

- **Roman building assets** placed at appropriate terrain zones (Colosseum, Pantheon, Temple, columns, market stalls, aqueduct chain)
- **Procedural buildings** (insulae and shops) filling residential areas with Mediterranean color palette
- **Roman-themed controls** (Senate Seats, Grain Dole, Tax Collectors) with descriptive subtitles
- **Enhanced particle behavior** with elite clustering at Forum, commoner clustering at Market, crisis jitter, and color shift from gold to red
- **Environmental state response** where building condition reflects State Health and market busyness reflects Wages
- **Ambient sound effects** with crowd murmur, birds, wind - all responding to game state
- **Tutorial system** with glowing path to first control and hint billboards that fade after use

## Files Changed

**New Files:**
- `src/shared/AssetConfig.luau` - All mesh IDs, sound IDs, colors, configurations
- `src/server/AssetPlacer.server.luau` - Places 3D mesh buildings at terrain zones
- `src/server/ProceduralBuildings.server.luau` - Generates Part-based insulae and shops
- `src/client/Environment.client.luau` - Building condition and dust particle effects
- `src/client/SoundEffects.client.luau` - Ambient and interaction sounds
- `src/client/Tutorial.client.luau` - Path particles and hint billboards

**Modified Files:**
- `src/server/Controls.server.luau` - Roman-themed names and descriptions
- `src/client/Particles.client.luau` - Clustering, avoidance, jitter, color shift

## Test Plan

- [ ] Start Rojo and connect Roblox Studio
- [ ] Verify Roman buildings appear at correct zones (Colosseum at Colosseum zone, Pantheon at Forum, etc.)
- [ ] Verify procedural insulae and shops fill residential areas
- [ ] Verify controls show Roman-themed names (Senate Seats, Grain Dole, Tax Collectors)
- [ ] Walk to Forum and verify path particles fade
- [ ] Stand on control plates and verify hint billboards fade
- [ ] Increase PSI and verify elite particles shift from gold to orange to red
- [ ] During crisis, verify particles jitter erratically
- [ ] Verify crowd sounds get louder and more agitated during crisis
- [ ] Verify bird sounds decrease during crisis
- [ ] Lower State Health and verify buildings darken
- [ ] Increase Wages and verify market stalls brighten

Closes #98

Generated with [Claude Code](https://claude.com/claude-code)