### PR TITLE
Add spawn location at ground level

### DIFF
--- a/roblox/rome-assets/rome-game/src/server/SpawnSetup.server.luau
+++ b/roblox/rome-assets/rome-game/src/server/SpawnSetup.server.luau
@@ -1,0 +1,25 @@
+--!strict
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Shared = ReplicatedStorage:WaitForChild("Shared")
+local TerrainUtils = require(Shared:WaitForChild("TerrainUtils"))
+
+-- Spawn at Forum center
+local SPAWN_X = 0
+local SPAWN_Z = 0
+
+-- Wait for terrain to generate
+task.wait(2)
+
+local groundY = TerrainUtils.getGroundY(SPAWN_X, SPAWN_Z)
+print("Setting spawn at ground level Y =", groundY)
+
+local spawn = Instance.new("SpawnLocation")
+spawn.Name = "ForumSpawn"
+spawn.Anchored = true
+spawn.CanCollide = false
+spawn.Transparency = 1
+spawn.Size = Vector3.new(6, 1, 6)
+spawn.Position = Vector3.new(SPAWN_X, groundY + 0.5, SPAWN_Z)
+spawn.Parent = workspace
+
+print("Spawn location created at", spawn.Position)


### PR DESCRIPTION
## Summary
- Creates `SpawnSetup.server.luau` that uses `TerrainUtils.getGroundY()` to find terrain height at Forum center (0, 0)
- Creates an invisible SpawnLocation Part at the correct Y position
- Ensures players start standing on ground rather than spawning in air or underground with procedural terrain

## Test plan
- [ ] Verify spawn location is created at correct ground level
- [ ] Test that players spawn standing on terrain
- [ ] Confirm spawn works with different terrain seeds

Closes #107

Generated with [Claude Code](https://claude.ai/code)