### PR TITLE
Fix Environment system finding 0 building parts

### DIFF
--- a/roblox/rome-assets/rome-game/src/client/Environment.client.luau
+++ b/roblox/rome-assets/rome-game/src/client/Environment.client.luau
@@ -50,6 +50,17 @@ local dustFolder: Folder?
 local dustParticles: { Part } = {}
 
 --[[
+    Count entries in a dictionary table.
+]]
+local function countDictionary(dict: { [any]: any }): number
+    local count = 0
+    for _ in pairs(dict) do
+        count = count + 1
+    end
+    return count
+end
+
+--[[
     Find and catalog all building parts for visual effects.
 ]]
 local function catalogBuildings()
@@ -64,7 +75,6 @@ local function catalogBuildings()
                 buildingParts[child] = child.Color
             end
         end
-        print(string.format("[Environment] Cataloged %d building parts", #buildingParts))
     end
 
     -- Find procedural buildings folder
@@ -77,13 +87,22 @@ local function catalogBuildings()
         end
     end
 
+    print(string.format("[Environment] Cataloged %d building parts", countDictionary(buildingParts)))
+
     -- Find market stalls specifically
+    -- Check RomanBuildings for direct children or descendants named MarketStall*
     if romanBuildings then
         for _, child in ipairs(romanBuildings:GetChildren()) do
             if child.Name:find("MarketStall") then
-                for _, part in ipairs(child:GetDescendants()) do
-                    if part:IsA("BasePart") then
-                        table.insert(marketStalls, part)
+                -- If it's a BasePart (from AssetPlacer), add it directly
+                if child:IsA("BasePart") then
+                    table.insert(marketStalls, child)
+                else
+                    -- If it's a Model, add its descendant parts
+                    for _, part in ipairs(child:GetDescendants()) do
+                        if part:IsA("BasePart") then
+                            table.insert(marketStalls, part)
+                        end
                     end
                 end
             end


### PR DESCRIPTION
## Summary
- Fixed `#buildingParts` returning 0 because Lua's `#` operator doesn't work on dictionaries - added `countDictionary()` helper function
- Fixed market stall detection: was looking for Models with descendant parts, but AssetPlacer creates direct BasePart children named "MarketStall_1", etc.

## Root Cause
1. `buildingParts` is a `{ [BasePart]: Color3 }` dictionary. Using `#buildingParts` in Lua always returns 0 for dictionaries (only works on sequential arrays).
2. Market stall detection code assumed MarketStall children were Models containing descendant parts, but AssetPlacer creates single BaseParts directly.

## Changes
- Added `countDictionary()` helper to properly count dictionary entries
- Updated market stall detection to handle both BaseParts (from AssetPlacer) and Models (future-proof)
- Moved the "Cataloged N building parts" log after both RomanBuildings and ProceduralBuildings are processed

## Test plan
- [ ] Run in Roblox Studio and verify Environment logs show non-zero counts:
  - `[Environment] Cataloged N building parts` (should show total parts from both folders)
  - `[Environment] Found N market stall parts` (should show 6 from AssetPlacer)
- [ ] Verify building visual effects (darkening/brightening) work when State Health changes
- [ ] Verify market stalls respond to Wage changes

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)