### PR TITLE
Fix music continuity - ensure playback never stops at PSI extremes

### DIFF
--- a/roblox/rome-assets/rome-game/src/client/Music.client.luau
+++ b/roblox/rome-assets/rome-game/src/client/Music.client.luau
@@ -8,6 +8,8 @@
     - Preloads all 6 music tracks
     - Smooth crossfading based on PSI value
     - Uses TweenService for volume transitions
+    - Continuous playback guaranteed (never stops)
+    - Periodic health checks ensure sounds keep playing
 ]]
 
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
@@ -37,6 +39,7 @@ local TWEEN_INFO = TweenInfo.new(MusicManager.getCrossfadeDuration(), Enum.Easin
 
 --[[
     Create a Sound object for a track.
+    All tracks are set to loop and play continuously (volume controls audibility).
 ]]
 local function createSound(track: MusicManager.MusicTrack, index: number): Sound
     local sound = Instance.new("Sound")
@@ -44,7 +47,15 @@ local function createSound(track: MusicManager.MusicTrack, index: number): Sound
     sound.SoundId = track.id
     sound.Volume = 0
     sound.Looped = true
+    sound.PlaybackSpeed = 1
     sound.Parent = SoundService
+
+    -- Ensure track restarts if it somehow stops (safety fallback)
+    sound.Ended:Connect(function()
+        if sound.Looped then
+            sound:Play()
+        end
+    end)
 
     print(string.format("  [%d] Loading: %s", index, track.name))
 
@@ -113,6 +124,18 @@ local function updateMusicForPsi(psi: number)
 end
 
 --[[
+    Ensure all sounds are playing (called periodically as a safety check).
+    Sounds play at volume 0 when inactive, ready for instant crossfade.
+]]
+local function ensureSoundsPlaying()
+    for _, sound in ipairs(sounds) do
+        if not sound.IsPlaying then
+            sound:Play()
+        end
+    end
+end
+
+--[[
     Handle PSI updates from server.
 ]]
 PsiUpdateEvent.OnClientEvent:Connect(function(psi: number)
@@ -124,6 +147,14 @@ initializeTracks()
 
 -- Set initial state (low PSI = first track)
 updateMusicForPsi(0.05)
+
+-- Periodic health check to ensure music never stops
+task.spawn(function()
+    while true do
+        task.wait(5) -- Check every 5 seconds
+        ensureSoundsPlaying()
+    end
+end)
 
 print("")
 print("Music system running!")

--- a/roblox/rome-assets/rome-game/src/shared/MusicManager.luau
+++ b/roblox/rome-assets/rome-game/src/shared/MusicManager.luau
@@ -9,6 +9,7 @@
     - High PSI: Intense, dramatic music
 
     Uses smooth crossfading between tracks to avoid jarring transitions.
+    IMPORTANT: Music should NEVER stop - always at least one track at full volume.
 ]]
 
 local MusicManager = {}
@@ -82,9 +83,13 @@ end
     Calculate volume levels for smooth crossfading between tracks.
     Returns volumes for current and next track based on PSI position.
 
-    When PSI is near a threshold, we crossfade between tracks:
-    - Within 0.02 of threshold: begin fading out current
-    - At threshold: fully transitioned to next track
+    IMPORTANT: Music should NEVER stop playing. At PSI extremes (0 or 1.0),
+    the appropriate track plays at full volume with no crossfade.
+
+    When PSI is near a threshold between tracks, we crossfade:
+    - Last 20% of range: fade out current, fade in next
+    - First track has no previous track to fade from
+    - Last track has no next track to fade to (always plays at full volume)
 ]]
 function MusicManager.calculateCrossfadeVolumes(psi: number): { [number]: number }
     local volumes: { [number]: number } = {}
@@ -93,6 +98,9 @@ function MusicManager.calculateCrossfadeVolumes(psi: number): { [number]: number
     for i = 1, #MUSIC_TRACKS do
         volumes[i] = 0
     end
+
+    -- Clamp PSI to valid range to prevent edge case issues
+    psi = math.clamp(psi, 0, 1)
 
     local currentIndex = MusicManager.getTrackIndexForPsi(psi)
     local currentTrack = MUSIC_TRACKS[currentIndex]
@@ -106,17 +114,21 @@ function MusicManager.calculateCrossfadeVolumes(psi: number): { [number]: number
     -- Crossfade zone is last 20% of range
     local crossfadeStart = 0.8
 
+    -- Special case: last track should never fade out (no next track)
+    -- At PSI 1.0, the last track plays at full volume
+    if currentIndex == #MUSIC_TRACKS then
+        volumes[currentIndex] = MAX_VOLUME
+        return volumes
+    end
+
     if positionInRange < crossfadeStart then
         -- Fully in current track
         volumes[currentIndex] = MAX_VOLUME
     else
-        -- In crossfade zone
+        -- In crossfade zone - fade to next track
         local crossfadeProgress = (positionInRange - crossfadeStart) / (1 - crossfadeStart)
         volumes[currentIndex] = MAX_VOLUME * (1 - crossfadeProgress)
-
-        if currentIndex < #MUSIC_TRACKS then
-            volumes[currentIndex + 1] = MAX_VOLUME * crossfadeProgress
-        end
+        volumes[currentIndex + 1] = MAX_VOLUME * crossfadeProgress
     end
 
     return volumes


### PR DESCRIPTION
## Summary
- Fix critical bug where volume dropped to 0 at PSI 1.0 (last track was in crossfade zone with no next track to fade to)
- Add PSI clamping (0-1) to prevent edge case issues with out-of-range values
- Add sound.Ended handler to restart looped tracks if they somehow stop
- Add periodic health check (every 5 seconds) to ensure all sounds stay playing
- Set explicit PlaybackSpeed = 1 for consistent playback

## Test plan
- [ ] Start game at low PSI (0.05) - Dawn track should play
- [ ] Increase PSI gradually to 1.0 - music should crossfade through all tracks
- [ ] At PSI 1.0 (max), Caesar track should play at full volume (not silence)
- [ ] Decrease PSI back to 0 - music should crossfade back to Dawn
- [ ] Let game run for several minutes - no gaps or silence should occur

Closes #116

Generated with [Claude Code](https://claude.com/claude-code)