### PR TITLE
Scale 3D models 4x and spread aqueducts for visibility

### DIFF
--- a/roblox/rome-assets/rome-game/src/server/AssetPlacer.server.luau
+++ b/roblox/rome-assets/rome-game/src/server/AssetPlacer.server.luau
@@ -337,14 +337,14 @@ end
 ]]
 local function placeAqueduct()
     local config = AssetConfig.Placements.RomanAqueduct
-    local segmentSpacing = 25
-    local startX = -150
+    local segmentSpacing = 70 -- Spread out for 4x scaled models
+    local startX = -200
     local startZ = 160 -- North of the main areas, near river
 
-    -- Create 5 aqueduct segments in a line
-    for i = 1, 5 do
+    -- Create 6 aqueduct segments in a line (longer chain for visual impact)
+    for i = 1, 6 do
         local x = startX + (i - 1) * segmentSpacing
-        local z = startZ + math.sin(i * 0.3) * 10 -- Slight curve
+        local z = startZ + math.sin(i * 0.3) * 15 -- Slight curve
 
         placeBuilding(
             "Aqueduct_" .. i,
@@ -382,4 +382,4 @@ print("  - Roman Temple")
 print("  - Triumphal Arch")
 print("  - 10 Doric Columns")
 print("  - 6 Market Stalls")
-print("  - 5 Aqueduct Segments")
+print("  - 6 Aqueduct Segments")

--- a/roblox/rome-assets/rome-game/src/shared/AssetConfig.luau
+++ b/roblox/rome-assets/rome-game/src/shared/AssetConfig.luau
@@ -42,40 +42,40 @@ AssetConfig.Colors = {
     RedTile = Color3.fromRGB(180, 80, 60),
 }
 
--- Building placement configurations
+-- Building placement configurations (4x scale for visibility)
 AssetConfig.Placements = {
     Colosseum = {
-        scale = Vector3.new(15, 15, 15),
+        scale = Vector3.new(60, 60, 60),
         rotation = 0,
         yOffset = 0,
     },
     Pantheon = {
-        scale = Vector3.new(12, 12, 12),
+        scale = Vector3.new(48, 48, 48),
         rotation = 180,
         yOffset = 0,
     },
     RomanTemple = {
-        scale = Vector3.new(8, 8, 8),
+        scale = Vector3.new(32, 32, 32),
         rotation = 0,
         yOffset = 0,
     },
     TriumphalArch = {
-        scale = Vector3.new(6, 6, 6),
+        scale = Vector3.new(24, 24, 24),
         rotation = 90,
         yOffset = 0,
     },
     RomanAqueduct = {
-        scale = Vector3.new(10, 10, 10),
+        scale = Vector3.new(40, 40, 40),
         rotation = 0,
         yOffset = 0,
     },
     DoricColumn = {
-        scale = Vector3.new(3, 3, 3),
+        scale = Vector3.new(12, 12, 12),
         rotation = 0,
         yOffset = 0,
     },
     MarketStall = {
-        scale = Vector3.new(4, 4, 4),
+        scale = Vector3.new(16, 16, 16),
         rotation = 0,
         yOffset = 0,
     },

--- a/roblox/rome-assets/rome-game/src/shared/AssetConfig.luau
+++ b/roblox/rome-assets/rome-game/src/shared/AssetConfig.luau
@@ -87,10 +87,10 @@ AssetConfig.Sounds = {
     PlateStep = "rbxassetid://6042053626", -- UI click
     PlateActivate = "rbxassetid://421058925", -- Soft chime
 
-    -- Ambient
-    CrowdMurmur = "rbxassetid://9116367423", -- Crowd ambient
-    Birds = "rbxassetid://9116367423", -- Bird chirps
-    Wind = "rbxassetid://9114082060", -- Wind ambient
+    -- Ambient (replaced 403-erroring IDs with working public sounds)
+    CrowdMurmur = "rbxassetid://926658585", -- People talking background
+    Birds = "rbxassetid://4915214793", -- Ambient birds
+    Wind = "rbxassetid://3645269782", -- Wind sound effect
 
     -- Effects
     Footstep = "rbxassetid://5892287796", -- Stone footstep


### PR DESCRIPTION
## Summary
- Increased all building scales by 4x in AssetConfig.luau for better visibility:
  - Colosseum: 15 -> 60
  - Pantheon: 12 -> 48  
  - RomanTemple: 8 -> 32
  - TriumphalArch: 6 -> 24
  - RomanAqueduct: 10 -> 40
  - DoricColumn: 3 -> 12
  - MarketStall: 4 -> 16
- Updated aqueduct placement with 70 stud spacing (was 25) and added a 6th segment for longer visual chain

## Test plan
- [ ] Run the game and verify buildings appear at the larger scale
- [ ] Verify aqueduct segments are properly spread out (70 studs apart)
- [ ] Confirm 6 aqueduct segments are placed instead of 5
- [ ] Check that buildings are not overlapping due to increased size

Closes #122

---
Generated with [Claude Code](https://claude.ai/code)