### PR TITLE
Reduce HUD and labels for cleaner UI (#121)

### DIFF
--- a/roblox/rome-assets/rome-game/src/client/HUD.client.luau
+++ b/roblox/rome-assets/rome-game/src/client/HUD.client.luau
@@ -40,66 +40,54 @@ screenGui.ResetOnSpawn = false
 screenGui.IgnoreGuiInset = true
 screenGui.Parent = playerGui
 
--- Create main container frame (top-center)
+-- Create main container frame (top-left corner, 50% smaller, more transparent)
 local container = Instance.new("Frame")
 container.Name = "Container"
-container.Size = UDim2.new(0, 300, 0, 100)
-container.Position = UDim2.new(0.5, -150, 0, 20)
+container.Size = UDim2.new(0, 120, 0, 50)
+container.Position = UDim2.new(0, 10, 0, 10)
 container.BackgroundColor3 = Color3.fromRGB(20, 20, 30)
-container.BackgroundTransparency = 0.3
+container.BackgroundTransparency = 0.6
 container.BorderSizePixel = 0
 container.Parent = screenGui
 
 -- Add corner rounding
 local corner = Instance.new("UICorner")
-corner.CornerRadius = UDim.new(0, 12)
+corner.CornerRadius = UDim.new(0, 6)
 corner.Parent = container
 
 -- Create year label at top
 local yearLabel = Instance.new("TextLabel")
 yearLabel.Name = "Year"
-yearLabel.Size = UDim2.new(1, 0, 0, 20)
-yearLabel.Position = UDim2.new(0, 0, 0, 6)
+yearLabel.Size = UDim2.new(1, 0, 0, 12)
+yearLabel.Position = UDim2.new(0, 0, 0, 4)
 yearLabel.BackgroundTransparency = 1
 yearLabel.Text = "100 BCE"
 yearLabel.TextColor3 = Color3.fromRGB(255, 220, 150)
-yearLabel.TextSize = 16
+yearLabel.TextSize = 10
 yearLabel.Font = Enum.Font.GothamBold
 yearLabel.Parent = container
 
--- Create title label
-local titleLabel = Instance.new("TextLabel")
-titleLabel.Name = "Title"
-titleLabel.Size = UDim2.new(1, 0, 0, 18)
-titleLabel.Position = UDim2.new(0, 0, 0, 28)
-titleLabel.BackgroundTransparency = 1
-titleLabel.Text = "POLITICAL STRESS"
-titleLabel.TextColor3 = Color3.fromRGB(180, 180, 200)
-titleLabel.TextSize = 12
-titleLabel.Font = Enum.Font.GothamBold
-titleLabel.Parent = container
-
--- Create percentage label
+-- Create percentage label (removed title label - just show the number)
 local percentLabel = Instance.new("TextLabel")
 percentLabel.Name = "Percent"
-percentLabel.Size = UDim2.new(1, 0, 0, 36)
-percentLabel.Position = UDim2.new(0, 0, 0, 44)
+percentLabel.Size = UDim2.new(1, 0, 0, 18)
+percentLabel.Position = UDim2.new(0, 0, 0, 16)
 percentLabel.BackgroundTransparency = 1
 percentLabel.Text = "5%"
 percentLabel.TextColor3 = Color3.fromRGB(255, 255, 255)
-percentLabel.TextSize = 32
+percentLabel.TextSize = 16
 percentLabel.Font = Enum.Font.GothamBold
 percentLabel.Parent = container
 
 -- Create status label
 local statusLabel = Instance.new("TextLabel")
 statusLabel.Name = "Status"
-statusLabel.Size = UDim2.new(1, 0, 0, 16)
-statusLabel.Position = UDim2.new(0, 0, 1, -22)
+statusLabel.Size = UDim2.new(1, 0, 0, 12)
+statusLabel.Position = UDim2.new(0, 0, 1, -14)
 statusLabel.BackgroundTransparency = 1
 statusLabel.Text = "Peaceful"
 statusLabel.TextColor3 = Color3.fromRGB(100, 200, 100)
-statusLabel.TextSize = 12
+statusLabel.TextSize = 8
 statusLabel.Font = Enum.Font.Gotham
 statusLabel.Parent = container
 

--- a/roblox/rome-assets/rome-game/src/client/Tutorial.client.luau
+++ b/roblox/rome-assets/rome-game/src/client/Tutorial.client.luau
@@ -187,7 +187,7 @@ local function fadePathParticles()
 end
 
 --[[
-    Create a floating hint billboard above a control.
+    Create a floating hint billboard above a control (subtle, smaller).
 ]]
 local function createHintBillboard(x: number, z: number, stationName: string): BillboardGui
     local groundY = TerrainUtils.getGroundY(x, z)
@@ -196,65 +196,55 @@ local function createHintBillboard(x: number, z: number, stationName: string): B
     local anchor = Instance.new("Part")
     anchor.Name = stationName .. "_HintAnchor"
     anchor.Size = Vector3.new(1, 1, 1)
-    anchor.Position = Vector3.new(x, groundY + 12, z)
+    anchor.Position = Vector3.new(x, groundY + 8, z)
     anchor.Anchored = true
     anchor.Transparency = 1
     anchor.CanCollide = false
     anchor.Parent = tutorialFolder
 
-    -- Create billboard
+    -- Create billboard (smaller, not always on top)
     local billboard = Instance.new("BillboardGui")
     billboard.Name = stationName .. "_Hint"
-    billboard.Size = UDim2.new(0, 250, 0, 100)
+    billboard.Size = UDim2.new(0, 120, 0, 35)
     billboard.StudsOffset = Vector3.new(0, 0, 0)
     billboard.Adornee = anchor
-    billboard.AlwaysOnTop = true
+    billboard.AlwaysOnTop = false
     billboard.Parent = anchor
 
-    -- Background frame
+    -- Background frame (more transparent)
     local frame = Instance.new("Frame")
     frame.Name = "Background"
     frame.Size = UDim2.new(1, 0, 1, 0)
     frame.BackgroundColor3 = Color3.fromRGB(30, 30, 40)
-    frame.BackgroundTransparency = 0.3
+    frame.BackgroundTransparency = 0.6
     frame.BorderSizePixel = 0
     frame.Parent = billboard
 
     local corner = Instance.new("UICorner")
-    corner.CornerRadius = UDim.new(0, 8)
+    corner.CornerRadius = UDim.new(0, 4)
     corner.Parent = frame
 
-    -- Hint text
+    -- Hint text (simplified, smaller)
     local hintLabel = Instance.new("TextLabel")
     hintLabel.Name = "HintText"
-    hintLabel.Size = UDim2.new(1, -10, 0.5, 0)
-    hintLabel.Position = UDim2.new(0, 5, 0, 5)
+    hintLabel.Size = UDim2.new(1, -6, 1, -6)
+    hintLabel.Position = UDim2.new(0, 3, 0, 3)
     hintLabel.BackgroundTransparency = 1
-    hintLabel.Text = "Stand on plates to control"
+    hintLabel.Text = "Step on plates"
     hintLabel.TextColor3 = AssetConfig.Tutorial.HintColor
-    hintLabel.TextSize = 14
-    hintLabel.Font = Enum.Font.GothamBold
+    hintLabel.TextTransparency = 0.2
+    hintLabel.TextSize = 10
+    hintLabel.Font = Enum.Font.Gotham
     hintLabel.TextXAlignment = Enum.TextXAlignment.Center
     hintLabel.Parent = frame
 
-    -- Instruction text
-    local instructionLabel = Instance.new("TextLabel")
-    instructionLabel.Name = "InstructionText"
-    instructionLabel.Size = UDim2.new(1, -10, 0.5, 0)
-    instructionLabel.Position = UDim2.new(0, 5, 0.5, 0)
-    instructionLabel.BackgroundTransparency = 1
-    instructionLabel.Text = "GREEN = Increase | RED = Decrease"
-    instructionLabel.TextColor3 = Color3.fromRGB(200, 200, 200)
-    instructionLabel.TextSize = 12
-    instructionLabel.Font = Enum.Font.Gotham
-    instructionLabel.TextXAlignment = Enum.TextXAlignment.Center
-    instructionLabel.Parent = frame
+    -- Removed instruction text for cleaner appearance
 
-    -- Glowing border
+    -- Subtle border
     local stroke = Instance.new("UIStroke")
     stroke.Color = AssetConfig.Tutorial.GlowColor
-    stroke.Thickness = 2
-    stroke.Transparency = 0.3
+    stroke.Thickness = 1
+    stroke.Transparency = 0.6
     stroke.Parent = frame
 
     table.insert(hintBillboards, billboard)

--- a/roblox/rome-assets/rome-game/src/server/Controls.server.luau
+++ b/roblox/rome-assets/rome-game/src/server/Controls.server.luau
@@ -103,15 +103,15 @@ local function createControlPlate(name: string, x: number, z: number, color: Col
 end
 
 --[[
-    Create a label above a plate.
+    Create a label above a plate (subtle, smaller).
 ]]
 local function createPlateLabel(plate: Part, text: string)
     local billboard = Instance.new("BillboardGui")
     billboard.Name = "PlateLabel"
-    billboard.Size = UDim2.new(0, 200, 0, 50)
-    billboard.StudsOffset = Vector3.new(0, 4, 0)
+    billboard.Size = UDim2.new(0, 80, 0, 20)
+    billboard.StudsOffset = Vector3.new(0, 2, 0)
     billboard.Adornee = plate
-    billboard.AlwaysOnTop = true
+    billboard.AlwaysOnTop = false
 
     local label = Instance.new("TextLabel")
     label.Name = "Label"
@@ -119,25 +119,26 @@ local function createPlateLabel(plate: Part, text: string)
     label.BackgroundTransparency = 1
     label.Text = text
     label.TextColor3 = Color3.new(1, 1, 1)
-    label.TextStrokeTransparency = 0.5
+    label.TextTransparency = 0.3
+    label.TextStrokeTransparency = 0.7
     label.TextScaled = true
-    label.Font = Enum.Font.GothamBold
+    label.Font = Enum.Font.Gotham
     label.Parent = billboard
 
     billboard.Parent = plate
 end
 
 --[[
-    Create a station title above the control area.
+    Create a station title above the control area (subtle, no subtitle).
 ]]
-local function createStationTitle(x: number, z: number, title: string, subtitle: string)
+local function createStationTitle(x: number, z: number, title: string, _subtitle: string)
     local groundY = TerrainUtils.getGroundY(x, z)
 
     -- Create an invisible anchor part
     local anchor = Instance.new("Part")
     anchor.Name = title .. "_Title"
     anchor.Size = Vector3.new(1, 1, 1)
-    anchor.Position = Vector3.new(x, groundY + 8, z)
+    anchor.Position = Vector3.new(x, groundY + 5, z)
     anchor.Anchored = true
     anchor.Transparency = 1
     anchor.CanCollide = false
@@ -145,34 +146,25 @@ local function createStationTitle(x: number, z: number, title: string, subtitle:
 
     local billboard = Instance.new("BillboardGui")
     billboard.Name = "StationTitle"
-    billboard.Size = UDim2.new(0, 300, 0, 80)
+    billboard.Size = UDim2.new(0, 100, 0, 25)
     billboard.StudsOffset = Vector3.new(0, 0, 0)
     billboard.Adornee = anchor
-    billboard.AlwaysOnTop = true
+    billboard.AlwaysOnTop = false
 
     local titleLabel = Instance.new("TextLabel")
     titleLabel.Name = "Title"
-    titleLabel.Size = UDim2.new(1, 0, 0.6, 0)
+    titleLabel.Size = UDim2.new(1, 0, 1, 0)
     titleLabel.Position = UDim2.new(0, 0, 0, 0)
     titleLabel.BackgroundTransparency = 1
     titleLabel.Text = title
     titleLabel.TextColor3 = Color3.fromRGB(255, 220, 150)
-    titleLabel.TextStrokeTransparency = 0.3
+    titleLabel.TextTransparency = 0.3
+    titleLabel.TextStrokeTransparency = 0.6
     titleLabel.TextScaled = true
-    titleLabel.Font = Enum.Font.GothamBold
+    titleLabel.Font = Enum.Font.Gotham
     titleLabel.Parent = billboard
 
-    local subtitleLabel = Instance.new("TextLabel")
-    subtitleLabel.Name = "Subtitle"
-    subtitleLabel.Size = UDim2.new(1, 0, 0.4, 0)
-    subtitleLabel.Position = UDim2.new(0, 0, 0.6, 0)
-    subtitleLabel.BackgroundTransparency = 1
-    subtitleLabel.Text = subtitle
-    subtitleLabel.TextColor3 = Color3.fromRGB(200, 200, 200)
-    subtitleLabel.TextStrokeTransparency = 0.5
-    subtitleLabel.TextScaled = true
-    subtitleLabel.Font = Enum.Font.Gotham
-    subtitleLabel.Parent = billboard
+    -- Removed subtitle for cleaner appearance
 
     billboard.Parent = anchor
 end


### PR DESCRIPTION
## Summary
- Move HUD from top-center to top-left corner to avoid mobile controls and Roblox default HUD
- Shrink HUD container by 50% (300x100 to 120x50 pixels)
- Increase transparency across all UI elements for less obtrusive appearance
- Reduce station labels (200x50 to 80x20) and station titles (300x80 to 100x25)
- Set AlwaysOnTop=false so labels don't obscure the 3D world
- Remove subtitle text from station titles
- Simplify tutorial hint billboards (250x100 to 120x35) with shortened text
- Remove redundant "POLITICAL STRESS" title from HUD - just show percentage

## Test plan
- [ ] Verify HUD appears in top-left corner and is smaller but readable
- [ ] Confirm station labels are visible when nearby but don't obstruct view
- [ ] Check tutorial hints are subtle but still guide new players
- [ ] Test on mobile to ensure HUD doesn't conflict with touch controls

Closes #121

Generated with [Claude Code](https://claude.com/claude-code)